### PR TITLE
Hack in a fix for robot.messageRoom()

### DIFF
--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -8,6 +8,7 @@ class Slack extends Adapter
     console.log "Sending message"
 
     user = @userFromParams(params)
+
     strings.forEach (str) =>
       # Escape this
       str = str.replace(/&/g, '&amp;')
@@ -34,7 +35,15 @@ class Slack extends Adapter
   userFromParams: (params) ->
     # hubot < 2.4.2: params = user
     # hubot >= 2.4.2: params = {user: user, ...}
-    if params.user then params.user else params
+    params = if params.user then params.user else params
+
+    # Ghetto hack to make robot.messageRoom work with Slack's adapter
+    #
+    # Note: Slack's API here uses rooom ID's, not room names. They look
+    # something like C0capitallettersandnumbershere
+    params.reply_to ||= params.room
+
+    params
 
   run: ->
     self = @


### PR DESCRIPTION
I'm not actually a big fan of this change, but the underlying idea here is to support Hubot's `robot.messageRoom()`.  Slack's adapter currently doesn't let us override the room, which ends up being undefined in that case.  At the moment we have to use room ID's instead of room names, which isn't super fun.  I looked around a bit and couldn't find any API docs, so maybe there is some way to use a room name here that I'm not aware of.

As I said, I don't love this code but it's the only way I could make the feature work.  This is basically a feature request in the form of a pull request.
