### PR TITLE
URL handling breaks assumptions of scripts?

### DIFF
--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -76,6 +76,7 @@ class Slack extends Adapter
       if hubot_msg
         # Convert markup into plain url string.
         hubot_msg = hubot_msg.replace(/<((\bhttps?)[^|]+)(\|(.*))+>/g, '< $1 >')
+        hubot_msg = hubot_msg.replace(/<((\bhttps?)(.*))?>/g, '< $1 >')
 
         # Unescape
         hubot_msg = hubot_msg.replace(/&amp;/g, '&')


### PR DESCRIPTION
Here's what I'm seeing when trying to use the factoid community script:
https://www.evernote.com/shard/s27/sh/023e547d-1bfc-4967-8869-ce2dadbca6db/b8e0456481ae8e5a92420f5897e0a26f

Here are the logs that I'm seeing, showing that html is being received by hubot:
https://gist.github.com/patcon/a1a92757b71a8d9a70ba

Here is the suspect code:
https://github.com/tinyspeck/hubot-slack/blob/master/src/slack.coffee#L77-L79

Can I ask why html is being added? Perhaps it's best to leave it alone? I'm unsure of your particular usecase, but the shouldn't the client (in this case, the slack ui interface) be handling the url transform itself?

I've pointed the slack guys to this issue, in case they have any insight.
