### PR TITLE
Totally remove url formatting

### DIFF
--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -75,8 +75,8 @@ class Slack extends Adapter
 
       if hubot_msg
         # Convert markup into plain url string.
-        hubot_msg = hubot_msg.replace(/<((\bhttps?)[^|]+)(\|(.*))+>/g, '< $1 >')
-        hubot_msg = hubot_msg.replace(/<((\bhttps?)(.*))?>/g, '< $1 >')
+        hubot_msg = hubot_msg.replace(/<((\bhttps?)[^|]+)(\|(.*))+>/g, '$1')
+        hubot_msg = hubot_msg.replace(/<((\bhttps?)(.*))?>/g, '$1')
 
         # Unescape
         hubot_msg = hubot_msg.replace(/&amp;/g, '&')


### PR DESCRIPTION
I think I left in the square brackets thinking it would be helpful, but it's messing up other hubot scripts:
https://www.evernote.com/shard/s27/sh/4cf39de9-2038-494a-aed7-4f15166eb5a8/9b006d210c324cf0db471fe4ccc04700

We should probably just remove it outright.
