### PR TITLE
Fixes for sending messages including multibyte characters

### DIFF
--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -163,6 +163,7 @@ class Slack extends Adapter
       headers  : headers
 
     if method is "POST"
+      body = new Buffer body
       reqOptions.headers["Content-Type"] = "application/x-www-form-urlencoded"
       reqOptions.headers["Content-Length"] = body.length
 


### PR DESCRIPTION
I tried to post messages including multibyte characters (Japanese) but I couldn't. And I received error messages below. I solved this problem by this change.

```
2013-11-16T14:49:05.288283+00:00 app[web.1]: Sending message
2013-11-16T14:49:05.335856+00:00 app[web.1]: No payload received
2013-11-16T14:49:05.335856+00:00 app[web.1]: Slack services error: 500
```
