### PR TITLE
Save known users to robot brain

### DIFF
--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -118,6 +118,7 @@ class Slack extends Adapter
 
       hubotMsg = self.getMessageFromRequest req
       author = self.getAuthorFromRequest req
+      user = self.robot.brain.userForId author.id, author.name
 
       if hubotMsg and author
         # Pass to the robot


### PR DESCRIPTION
Been having issues with the pagerduty script not recognizing or remembering users, and I think it has to do with `hubot-slack` not appending user data into the brain like so:
https://github.com/github/hubot/blob/master/src/adapters/campfire.coffee#L56-L67

Looking into my redis database, it's looking like the "users" key is totally empty, which I don't think is expected a adapters.

Thoughts? Any rationale for the users hash not being used, or was it just an oversight that hadn't caused issues yet?

Thanks!
