### PR TITLE
Added support for link_names in message formatting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,7 @@ Optional. If you entered `blacklist`, Hubot will not post in the rooms specified
 #### HUBOT\_SLACK\_CHANNELS
 
 Optional. A comma-separated list of channels to either be blacklisted or whitelisted, depending on the value of HUBOT_SLACK_CHANNELMODE.
+
+#### HUBOT\_SLACK\_LINK\_NAMES
+
+Optional. By default, Slack will not linkify channel names (starting with a '#') and usernames (starting with an '@'). You can enable this behavior by setting HUBOT_SLACK_LINK_NAMES to 1. Otherwise, defaults to 0. See [Slack API : Message Formatting Docs](https://api.slack.com/docs/formatting) for more information.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,10 @@
     },
     {
       "name": "Patrick Connolly"
+    },
+    {
+      "name": "Chip Hayner",
+      "email": "chayner@centresource.com"
     }
   ],
   "keywords": [

--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -22,9 +22,10 @@ class Slack extends Adapter
     strings.forEach (str) =>
       str = @escapeHtml str
       args = JSON.stringify
-        username : @robot.name
-        channel  : user.reply_to
-        text     : str
+        username   : @robot.name
+        channel    : user.reply_to
+        text       : str
+        link_names : @options.link_names
 
       @post "/services/hooks/hubot", args
 
@@ -88,6 +89,7 @@ class Slack extends Adapter
       name  : process.env.HUBOT_SLACK_BOTNAME or 'slackbot'
       mode  : process.env.HUBOT_SLACK_CHANNELMODE or 'blacklist'
       channels: process.env.HUBOT_SLACK_CHANNELS?.split(',') or []
+      link_names: process.env.HUBOT_SLACK_LINK_NAMES or 0
 
   getMessageFromRequest: (req) ->
     # Parse the payload


### PR DESCRIPTION
By default, when Slack receives a message returned by Hubot, it will not linkify channel names (starting with a '#') and usernames (starting with an '@'). This adds an environment variable that allows you to turn this formatting on (by setting HUBOT_SLACK_LINK_NAMES to 1).
