### PR TITLE
Fix for user data not persisting in brain

### DIFF
--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -102,8 +102,6 @@ class Slack extends Adapter
     # Return an author object
     id       : req.param 'user_id'
     name     : req.param 'user_name'
-    reply_to : req.param 'channel_id'
-    room     : req.param 'channel_name'
 
 
   ###################################################################
@@ -124,6 +122,9 @@ class Slack extends Adapter
 
       hubotMsg = self.getMessageFromRequest req
       author = self.getAuthorFromRequest req
+      author = self.robot.brain.userForId author.id, author
+      author.room = req.param 'channel_name'
+      author.reply_to = req.param 'channel_id'
 
       if hubotMsg and author
         # Pass to the robot


### PR DESCRIPTION
These changes (credit to @patcon) seem to at least roughly allow user data to be persisted, similar to how the Campfire adapter works.  

_NOTE the hubot-slack adapter also appears to depend on the latest version of Hubot.  And when upgrading, we ran into issues with some of our scripts, mainly because some methods have been moved from Robot to Brain._  E.g.:

```
robot.userForId id
```

should instead be used like

```
robot.brain.userForId id
```
