### PR TITLE
Security: Do not log every chat message

### DIFF
--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -128,7 +128,6 @@ class Slack extends Adapter
 
       if hubotMsg and author
         # Pass to the robot
-        self.log "Received #{hubotMsg} from #{author.name}"
         self.receive new TextMessage(author, hubotMsg)
 
       # Just send back an empty reply, since our actual reply,


### PR DESCRIPTION
Currently every chat message that any user sends to any room that hubot is listening in is logged.

By logging all messages (regardless of if they were matched or not) it creates a record of all messages that could easily be unintentionally created.
