### PR TITLE
Fix #messageRoom

### DIFF
--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -22,7 +22,10 @@ class Slack extends Adapter
   ###################################################################
   send: (envelope, strings...) ->
     @log "Sending message"
-    channel = envelope.reply_to || @channelMapping[envelope.room]
+    channel = envelope.reply_to || envelope.room
+
+    if channel[0] != 'C'
+      channel = "##{channel}"
 
     strings.forEach (str) =>
       str = @escapeHtml str


### PR DESCRIPTION
Depending on whether messageRoom or reply is used, the channel could be either a C*****\* slack channel code or the literal name, like 'general'. The former can be passed directly; the latter requires leading with a pound sign. So, this fixes #messageRoom without breaking #reply.

I'd love to update the tests, but I have no idea how to run them. So, if anyone wouldn't mind posting a link or some instructions, that would be great.
