### PR TITLE
Fix for broken test runner 🎉🎉🎉

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "email": "help@tinyspeck.com"
   },
   "devDependencies": {
-    "coffee-script": ">=1.6.0",
+    "coffee-script": "~1.7.1",
     "grunt": "~0.4.1",
     "grunt-release": "~0.6.0",
     "should": "~2.0.2",


### PR DESCRIPTION
On running `npm test` we got:

```
node_modules/hubot-slack/test/slack.coffee:1
(function (exports, require, module, __filename, __dirname) { ################
                                                              ^
SyntaxError: Unexpected token ILLEGAL
```

An issue with broken `npm test` was related to a fact that coffee-script prior v1.6.0 and after require slightly different arguments for `mocha`

So for coffee < 1.6.0 you had to run `mocha --compilers coffee:coffee-script --reporter spec` and for 1.6.0 and above `mocha --compilers coffee:coffee-script/register --reporter spec`

As coffee-script version specified in package.json was `>=1.2.0` - latest one was installed in any case, so i've updated dependency to run on `>=1.6.0` and added required arguments to mocha command.

@grantmd, @evansolomon what do you feel about increasing coffee version dependency?
