### PR TITLE
Allow messages to be manually sent to any room.

### DIFF
--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -22,7 +22,7 @@ class Slack extends Adapter
   ###################################################################
   send: (envelope, strings...) ->
     @log "Sending message"
-    channel = envelope.reply_to || @channelMapping[envelope.room]
+    channel = envelope.reply_to || @channelMapping[envelope.room] || envelope.room
 
     strings.forEach (str) =>
       str = @escapeHtml str
@@ -49,7 +49,7 @@ class Slack extends Adapter
   custom: (message, data)->
     @log "Sending custom message"
 
-    channel = message.reply_to || @channelMapping[message.room]
+    channel = message.reply_to || @channelMapping[message.room] || message.room
 
     attachment =
       text     : @escapeHtml data.text
@@ -123,14 +123,14 @@ class Slack extends Adapter
     # hubot >= 2.4.2: params = {user: user, ...}
     user = {}
     if params.user
-      user = params.user 
-    else 
+      user = params.user
+    else
       user = params
 
     if user.room and not user.reply_to
       user.reply_to = user.room
 
-    user 
+    user
   ###################################################################
   # The star.
   ###################################################################


### PR DESCRIPTION
So I spent the better part of today trying to get https://github.com/jonursenbach/hubot-jenkins-notifier working on Slack only to realize something very silly. 

As I was pushing up changes and trying to figure out why it wouldn't send a message to a room of mine, I realized how `@channelMapping` works. The way that this works is that in order to send a message to a room, the bot has to be aware of that room (which it can only be if it's previously sent something to said room).

So as I was rebooting my bot, this memory store was getting dumped out and when I was sending my notification to the room, hubot-slack didn't know about it because I hadn't interacted with my bot in there.

And that brings me to this change.

What if I wanted to send something (like a Jenkins notification) to a room that the bot doens't know about (like a private room, or any room that the bot hasn't been interacted with in). You can't.

Well now you can.

Instead of just relying on handling the channel name (`#general`, `#engineering`, etc.) you can now pass the bot a channel ID (`CSOMEJUMBLEOFALPHANUM`, `GSOMEJUMBLEOFALPHANUM`).

If the bot can't find the name of a room in the `@channelMapping`, it falls back to whatever string you gave it and then sends the message away. Of course, if that room doesn't exist you'll get a failure, but that's your fault.
