### PR TITLE
Correct default value of HUBOT_SLACK_BOTNAME in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ This is your team's Slack subdomain. For example, if your team is `https://mytea
 
 #### HUBOT\_SLACK\_BOTNAME
 
-Optional. What your Hubot is called on Slack. If you entered `slack-hubot` here, you would address your bot like `slack-hubot: help`. Otherwise, defaults to `hubot`.
+Optional. What your Hubot is called on Slack. If you entered `slack-hubot` here, you would address your bot like `slack-hubot: help`. Otherwise, defaults to `slackbot`.
 
 #### HUBOT\_SLACK\_CHANNELMODE
 


### PR DESCRIPTION
Spent few minutes to figure out there's something wrong in README doc.
Guessed you will prefer `slackbot` instead of `hubot`.
