### PR TITLE
Procfile -n flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ This is a modified set of instructions based on the [instructions on the Hubot w
 - Make sure `hubot-slack` is in your `package.json` dependencies
 - Edit your `Procfile` and change it to use the `slack` adapter:
 
-        web: bin/hubot --adapter slack
+        web: bin/hubot -a slack -n Hubot
+
 
 - Install [heroku toolbelt](https://toolbelt.heroku.com/) if you haven't already.
 - `heroku create my-company-slackbot`


### PR DESCRIPTION
Hello,

I noticed that I needed the following in my Procfile:
`web: bin/hubot -a slack -n Hubot`

Without the -n Hubot flag I was getting the following in my Heroku logs:
`Process exited with status
 0`

Heroku log snippet:

```
[Sun Apr 06 2014 21:51:20 GMT+0000 (UTC)] INFO Data for brain retrieved from Redis
[Sun Apr 06 2014 21:51:20 GMT+0000 (UTC)] INFO Successfully authenticated to Redis
State changed from starting to up
Process exited with status 0
```

Let me know if you need any more information.

Thanks
