### PR TITLE
Remove full options log from slothbot

### DIFF
--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -138,8 +138,6 @@ class Slack extends Adapter
     self = @
     @parseOptions()
 
-    @log "Slack adapter options:", @options
-
     return @logError "No services token provided to Hubot" unless @options.token
     return @logError "No team provided to Hubot" unless @options.team
 


### PR DESCRIPTION
The slack access token is logged in plain text. It's just easiest to get
rid of the whole line.
