### PR TITLE
Reference envelope.user if exists to support legacy hubot script

### DIFF
--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -21,8 +21,8 @@ class Slack extends Adapter
   # robot.respond, robot.listen, etc.
   ###################################################################
   send: (envelope, strings...) ->
+    channel = envelope.reply_to || envelope.user?.reply_to || @channelMapping[envelope.room] || envelope.user?.room || envelope.room
     @log "Sending message"
-    channel = envelope.reply_to || @channelMapping[envelope.room] || envelope.room
 
     strings.forEach (str) =>
       str = @escapeHtml str


### PR DESCRIPTION
Hi,

I tried using [hubot-cron](https://github.com/miyagawa/hubot-cron), however it does not work because fields that expected to be contained in `envelope` are under `envelope.user` object.

I think some of legacy hubot scripts are using `envelope.user` object.

So I added a line to support those legacy hubot scripts.
