### PR TITLE
Check for stings existance before escaping

### DIFF
--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -67,26 +67,28 @@ class Slack extends Adapter
   # HTML helpers.
   ###################################################################
   escapeHtml: (string) ->
-    string
-      # Escape entities
-      .replace(/&/g, '&amp;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;')
-
-      # Linkify. We assume that the bot is well-behaved and
-      # consistently sending links with the protocol part
-      .replace(/((\bhttp)\S+)/g, '<$1>')
+    if string
+      string
+        # Escape entities
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+  
+        # Linkify. We assume that the bot is well-behaved and
+        # consistently sending links with the protocol part
+        .replace(/((\bhttp)\S+)/g, '<$1>')
 
   unescapeHtml: (string) ->
-    string
-      # Unescape entities
-      .replace(/&amp;/g, '&')
-      .replace(/&lt;/g, '<')
-      .replace(/&gt;/g, '>')
-
-      # Convert markup into plain url string.
-      .replace(/<((\bhttps?)[^|]+)(\|(.*))+>/g, '$1')
-      .replace(/<((\bhttps?)(.*))?>/g, '$1')
+    if string
+      string
+        # Unescape entities
+        .replace(/&amp;/g, '&')
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>')
+  
+        # Convert markup into plain url string.
+        .replace(/<((\bhttps?)[^|]+)(\|(.*))+>/g, '$1')
+        .replace(/<((\bhttps?)(.*))?>/g, '$1')
 
 
   ###################################################################


### PR DESCRIPTION
If you do not specify one or more of the strings of an Attachment, it will fail to send the message because escaping the strings will fail. Let's check for the existance of said strings before we do escape them and thus avoid these problems.
I tested this on my local copy from npm and it works perfectly.
