### PR TITLE
Add link unfurling option

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ Optional. A comma-separated list of channels to either be blacklisted or whiteli
 
 Optional. By default, Slack will not linkify channel names (starting with a '#') and usernames (starting with an '@'). You can enable this behavior by setting HUBOT_SLACK_LINK_NAMES to 1. Otherwise, defaults to 0. See [Slack API : Message Formatting Docs](https://api.slack.com/docs/formatting) for more information.
 
+#### HUBOT\_SLACK\_UNFURL\_LINKS
+
+Optional. By default, Slack will not unfurl links. You can enable this behavior by setting HUBOT\_SLACK\_UNFURL\_LINKS to 1. Otherwise, defaults to 0.
+
 ## Under the Hood
 
 #### Receiving Messages:

--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -27,10 +27,11 @@ class Slack extends Adapter
     strings.forEach (str) =>
       str = @escapeHtml str
       args = JSON.stringify
-        username   : @robot.name
-        channel    : channel
-        text       : str
-        link_names : @options.link_names if @options?.link_names?
+        username     : @robot.name
+        channel      : channel
+        text         : str
+        link_names   : @options.link_names if @options?.link_names?
+        unfurl_links : @options.unfurl_links if @options?.unfurl_links?
 
       @post "/services/hooks/hubot", args
 
@@ -60,12 +61,13 @@ class Slack extends Adapter
         fields    : item.fields
         mrkdwn_in : item.mrkdwn_in
     args = JSON.stringify
-      username    : message.username || @robot.name
-      icon_url    : message.icon_url
-      icon_emoji  : message.icon_emoji
-      channel     : channel
-      attachments : attachments
-      link_names  : @options.link_names if @options?.link_names?
+      username     : message.username || @robot.name
+      icon_url     : message.icon_url
+      icon_emoji   : message.icon_emoji
+      channel      : channel
+      attachments  : attachments
+      link_names   : @options.link_names if @options?.link_names?
+      unfurl_links : @options.unfurl_links if @options?.unfurl_links?
     @post "/services/hooks/hubot", args
   ###################################################################
   # HTML helpers.
@@ -115,6 +117,7 @@ class Slack extends Adapter
       channels: (process.env.HUBOT_SLACK_CHANNELS?.split(',') or []).map (channel) ->
         channel.replace /^#/, ''
       link_names: process.env.HUBOT_SLACK_LINK_NAMES or 0
+      unfurl_links: process.env.HUBOT_SLACK_UNFURL_LINKS or 0
 
   getMessageFromRequest: (req) ->
     # Check the token


### PR DESCRIPTION
This is similar/the same as issue #17 but that has been dormant for a while. I'm creating this request as it's based off of latest master.

The changes are simple, basically just duplicating the code for LINK_NAMES and that's it!

As a note, the other PR mentioned not knowing what unfurling is. In this case it allows Slack to automatically grab information about a link sent to it and embeds it in the chat. For example, posting a .jpg would cause Slack to unfurl it by grabbing the image and embedding it into the chat.

The removes are simply adding spaces to make the code more readable as "unfurl_links" is longer than other options.
