### PR TITLE
Update README with the install recommendations of hubot

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,11 @@ This is a [Hubot](http://hubot.github.com/) adapter to use with [Slack](https://
 
 #### Creating a new bot
 
-- `npm install -g hubot coffee-script`
-- `hubot --create [path_name]`
-- `cd [path_name]`
+Use the yeoman generator :
+- `npm install -g yo generator-hubot coffee-script`
+- `mkdir hubot-slack`
+- `cd hubot-slack`
+- `yo hubot`
 - `npm install hubot-slack --save`
 - Initialize git and make your initial commit
 - Check out the [hubot docs](https://github.com/github/hubot/tree/master/docs) for further guidance on how to build your bot


### PR DESCRIPTION
Like mention when using the previous commands

``` bash
$ hubot --create .
'hubot --create' is depreated. Use the yeoman generator instead:
    npm install -g yo generator-hubot
    mkdir -p .
    yo hubot
   See https://github.com/github/hubot/blob/master/docs/README.md for more details on getting started.
```

Maybe it's a good idea to change the README ?

Tell me
