### PR TITLE
Update Upgrade instructions to use npm from npm instead of from git

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ need to upgrade:
 
 - Go to https://my.slack.com/services/new/hubot and create a new hubot
   integration
-- Run `npm install git+ssh://git@github.com:slackhq/hubot-slack.git --save`
+- Run `npm install hubot-slack --save`
   to update your code.
 - Test your bot locally using:
   `HUBOT_SLACK_TOKEN=xoxb-1234-5678-91011-00e4dd ./bin/hubot --adapter slack`


### PR DESCRIPTION
I'm not sure the original reason to install with `git+ssh://git@github.com:slackhq/hubot-slack.git` is, but in general, using a released version on npm is going to be better.

I think this would address this problem reported on twitter: https://twitter.com/jackmcdade/status/542036421360750593
