### PR TITLE
Split up messages if longer than 4000 chars

### DIFF
--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -117,17 +117,22 @@ class SlackBot extends Adapter
         submessages = []
 
         while msg.length > 0
-          # Split message at last line break, if it exists
-          chunk = msg.substring(0, MAX_MESSAGE_LENGTH)
-          breakIndex = chunk.lastIndexOf('\n')
-          breakIndex = MAX_MESSAGE_LENGTH if breakIndex is -1
+          if msg.length <= MAX_MESSAGE_LENGTH
+            submessages.push msg
+            msg = ''
 
-          submessages.push msg.substring(0, breakIndex)
+          else
+            # Split message at last line break, if it exists
+            chunk = msg.substring(0, MAX_MESSAGE_LENGTH)
+            breakIndex = chunk.lastIndexOf('\n')
+            breakIndex = MAX_MESSAGE_LENGTH if breakIndex is -1
 
-          # Skip char if split on line break
-          breakIndex++ if breakIndex isnt MAX_MESSAGE_LENGTH
+            submessages.push msg.substring(0, breakIndex)
 
-          msg = msg.substring(breakIndex, msg.length)
+            # Skip char if split on line break
+            breakIndex++ if breakIndex isnt MAX_MESSAGE_LENGTH
+
+            msg = msg.substring(breakIndex, msg.length)
 
         channel.send m for m in submessages
 


### PR DESCRIPTION
This PR addresses and fixes #104.

Presently, if a message longer than 4000 chars / 16k bytes in size is sent, the [RTM API](https://api.slack.com/rtm) will reject the message and close the connection to Hubot. This is easily reproducible by calling `hubot help` once a sizable amount of scripts are added to the bot. Hubot will still be alive, but it stays disconnected from Slack and requires a restart before we can start talking to our robotic friend again.

This PR checks to see if a message is longer than 4000 chars before it is sent, and if it is longer than 4000 chars, it will split the message into chunks and send each one at a time. It will also attempt to split the message at the last occurring line break (within the 4000 char limit) to try to result in cleaner message chunks.
