### PR TITLE
Better handling of users (fixes #93)

### DIFF
--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -67,13 +67,13 @@ class SlackBot extends Adapter
     return if not msg.user
 
     channel = @client.getChannelGroupOrDMByID msg.channel
-    user = @client.getUserByID msg.user
+    slackUser = @client.getUserByID msg.user
 
     # Ignore our own messages
-    return if user.name == @robot.name
+    return if slackUser.name == @robot.name
 
     # Process the user into a full hubot user
-    user = @robot.brain.userForId user.name
+    user = @robot.brain.userForId slackUser.id, {name: slackUser.name, email_address: slackUser.profile.email}
     user.room = channel.name
 
     # Test for enter/leave messages


### PR DESCRIPTION
This pull request makes our handling of users slightly better.

Before the user object attached to a message used the name as an ID, and only contained the name. Now, we correctly use user IDs when storing user objects in the Hubot brain. It also includes email addresses, to fix #93.
