### PR TITLE
Improve long message splitting and add tests

### DIFF
--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -123,13 +123,21 @@ class SlackBot extends Adapter
 
           else
             # Split message at last line break, if it exists
-            chunk = msg.substring(0, SlackBot.MAX_MESSAGE_LENGTH)
-            breakIndex = chunk.lastIndexOf('\n')
-            breakIndex = SlackBot.MAX_MESSAGE_LENGTH if breakIndex is -1
+            maxSizeChunk = msg.substring(0, SlackBot.MAX_MESSAGE_LENGTH)
+
+            lastLineBreak = maxSizeChunk.lastIndexOf('\n')
+            lastWordBreak = maxSizeChunk.match(/\W\w+$/)?.index
+
+            breakIndex = if lastLineBreak > -1
+              lastLineBreak
+            else if lastWordBreak
+              lastWordBreak
+            else
+              SlackBot.MAX_MESSAGE_LENGTH
 
             submessages.push msg.substring(0, breakIndex)
 
-            # Skip char if split on line break
+            # Skip char if split on line or word break
             breakIndex++ if breakIndex isnt SlackBot.MAX_MESSAGE_LENGTH
 
             msg = msg.substring(breakIndex, msg.length)

--- a/test/slack.coffee
+++ b/test/slack.coffee
@@ -63,3 +63,16 @@ describe 'Send Messages', ->
     sentMessage = sentMessages.pop()
     sentMessage.length.should.equal Math.ceil(len / SlackBot.MAX_MESSAGE_LENGTH)
 
+  it 'Should try to split on word breaks', ->
+    msg = 'Foo bar baz'
+    slackbot.constructor.MAX_MESSAGE_LENGTH = 10
+    sentMessages = slackbot.send {room: 'room-name'}, msg
+    sentMessage = sentMessages.pop()
+    sentMessage.length.should.equal 2
+
+  it 'Should split into max length chunks if there are no breaks', ->
+    msg = 'Foobar'
+    slackbot.constructor.MAX_MESSAGE_LENGTH = 3
+    sentMessages = slackbot.send {room: 'room-name'}, msg
+    sentMessage = sentMessages.pop()
+    sentMessage.should.eql ['Foo', 'bar']


### PR DESCRIPTION
- If a long message doesn't have line breaks, try to split on word breaks
- Unit tests for various splitting cases

Follow up to #107 
