### PR TITLE
Fail harder on errors

### DIFF
--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -38,7 +38,8 @@ class SlackBot extends Adapter
   error: (error) =>
     @robot.logger.error "Received error #{error.toString()}"
     @robot.logger.error error.stack
-    process.exit 1
+    @robot.logger.error "Exiting in 1 second"
+    setTimeout process.exit.bind(process, 1), 1000
 
   loggedIn: (self, team) =>
     @robot.logger.info "Logged in as #{self.name} of #{team.name}, but not yet connected"


### PR DESCRIPTION
Currently if the client emits an error we log it but just hang around.
The app is in an undefined state at that point so it's hard to say
what exactly will happen, but it's probably not ideal.

At least this way a process monitor can tell that it died and restart
it, ship the logs somewhere, or something.
