### PR TITLE
Fix @user mentions

### DIFF
--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -127,7 +127,7 @@ class SlackBot extends Adapter
     txt.replace /\<(@\w+)(?:\|([^>]+))?\>/g, (m, link, label) =>
       if label
         return label
-      u = @robot.brain.userForId link[1..]
+      u = @client.getUserByID link[1..]
       if u
         return "@#{u.name}"
       link

--- a/test/slack.coffee
+++ b/test/slack.coffee
@@ -16,13 +16,12 @@ beforeEach ->
     channel:
       send: (msg) -> msg
     client:
+      getUserByID: (id) ->
+        {name: 'name', email_address: 'email@example.com'}
       getChannelGroupOrDMByName: () ->
         stubs.channel
     # Hubot.Robot instance
     robot:
-      brain:
-        userForId: ->
-          {name: 'name', email_address: 'email@example.com'}
       logger:
         info: ->
         debug: ->
@@ -50,7 +49,7 @@ describe 'Login', ->
     slackbot.loggedIn(user, team)
     slackbot.robot.name.should.equal 'bot'
 
-describe 'message formatting', ->
+describe 'Removing message formatting', ->
 
   it 'Should do nothing if there are no user links', ->
     foo = slackbot.removeFormatting 'foo'


### PR DESCRIPTION
This pull request fixes #106. It does so by replacing slack's `<@U1234>` formatting with the equivalent `@username` before passing the message onto the rest of hubot.  As a result @-mentions work correctly when addressing hubot directly (eg: "@​hubot: ping") but also elsewhere in messages (eg: "@​hubot: what roles does @​ph have").

It fixes half of #9. A similar fix could be applied to the other half easily enough...
