### PR TITLE
terminate Hubot when Slack disconnects

### DIFF
--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -60,6 +60,7 @@ class SlackBot extends Adapter
     @client.removeListener 'open', @.open
     @client.removeListener 'close', @.close
     @client.removeListener 'message', @.message
+    process.exit 0
 
   message: (msg) =>
     return if msg.hidden


### PR DESCRIPTION
Since the adapter currently does nothing when there's a Slack disconnect, kill the hubot to indicate a problem.

In many cases, the process manager (supervisord, etc.) will restart it.
