### PR TITLE
Handle existing hubot brains with incomplete user data

### DIFF
--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -32,6 +32,7 @@ class SlackBot extends Adapter
     @client.on 'close', @.close
     @client.on 'message', @.message
     @client.on 'userChange', @.userChange
+    @robot.brain.on 'loaded', @.brainLoaded
 
     # Start logging in
     @client.login()
@@ -53,6 +54,15 @@ class SlackBot extends Adapter
 
     for id, user of @client.users
       @userChange user
+
+  brainLoaded: =>
+    # once the brain has loaded, reload all the users from the client
+    for id, user of @client.users
+      @userChange user
+
+    # also wipe out any broken users stored under usernames instead of ids
+    for id, user of @robot.brain.data.users
+      if id is user.name then delete @robot.brain.data.users[user.id]
 
   userChange: (user) =>
     newUser = {name: user.name, email_address: user.profile.email}


### PR DESCRIPTION
This pull request fixes #123.

The problem happened if someone had an existing robot brain with a user property stored in it - our code to load users on startup ran before the brain was loaded, then when the brain was loaded the user list got wiped out. This fixes that by rerunning the code to update users after the brain loads.
