### PR TITLE
Strip mailto: from mailto: links

### DIFF
--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -165,6 +165,7 @@ class SlackBot extends Adapter
       (?:\|([^>]+))? # label
       >              # closing angle bracket
     ///g, (m, link, label) =>
+      link = link.replace /^mailto:/, ''
       if label
         "#{label} #{link}"
       else

--- a/test/slack.coffee
+++ b/test/slack.coffee
@@ -93,13 +93,17 @@ describe 'Removing message formatting', ->
     foo = slackbot.removeFormatting 'foo <https://www.example.com> bar'
     foo.should.equal 'foo https://www.example.com bar'
 
-  it 'Should remove formatting around <mailto> links', ->
-    foo = slackbot.removeFormatting 'foo <mailto:name@example.com> bar'
-    foo.should.equal 'foo mailto:name@example.com bar'
+  it 'Should remove formatting around <skype> links', ->
+    foo = slackbot.removeFormatting 'foo <skype:echo123?call> bar'
+    foo.should.equal 'foo skype:echo123?call bar'
 
   it 'Should remove formatting around <https> links with a label', ->
     foo = slackbot.removeFormatting 'foo <https://www.example.com|label> bar'
     foo.should.equal 'foo label https://www.example.com bar'
+
+  it 'Should remove formatting around <mailto> links', ->
+    foo = slackbot.removeFormatting 'foo <mailto:name@example.com> bar'
+    foo.should.equal 'foo name@example.com bar'
 
   it 'Should change multiple links at once', ->
     foo = slackbot.removeFormatting 'foo <@U123|label> bar <#C123> <!channel> <https://www.example.com|label>'


### PR DESCRIPTION
This fixes an issue raised [here](https://github.com/slackhq/hubot-slack/issues/114#issuecomment-67356150) and [here](https://github.com/hubot-scripts/hubot-pager-me/pull/24). Slack's servers add a mailto: to email addresses, but most hubot scripts aren't expecting this.
