### PR TITLE
Strip formatting better, use new SlackTextMessage class

### DIFF
--- a/test/slack.coffee
+++ b/test/slack.coffee
@@ -99,7 +99,7 @@ describe 'Removing message formatting', ->
 
   it 'Should remove formatting around <https> links with a label', ->
     foo = slackbot.removeFormatting 'foo <https://www.example.com|label> bar'
-    foo.should.equal 'foo label https://www.example.com bar'
+    foo.should.equal 'foo label bar'
 
   it 'Should remove formatting around <mailto> links', ->
     foo = slackbot.removeFormatting 'foo <mailto:name@example.com> bar'
@@ -107,7 +107,7 @@ describe 'Removing message formatting', ->
 
   it 'Should change multiple links at once', ->
     foo = slackbot.removeFormatting 'foo <@U123|label> bar <#C123> <!channel> <https://www.example.com|label>'
-    foo.should.equal 'foo label bar #general @channel label https://www.example.com'
+    foo.should.equal 'foo label bar #general @channel label'
 
 describe 'Send Messages', ->
   it 'Should send multiple messages', ->


### PR DESCRIPTION
Rewrite the `removeFormatting` method to remove formatting in a slightly 
better way:
- Uses one pass instead of two for link handling
- Displays just the label instead of "#{link} #{label}" for regular
  links with labels. I don't know why it was using both, that produces
  weird output like
  
  > apple.com http://apple.com
- Removes entities, which the old version didn't even try to handle

Add a new exported SlackTextMessage class that contains both the parsed 
message (as `@text`) and the "raw" message (as `@rawText`). This provides an easy
way for scripts to detect that the message came from the Slack adapter and
handle the unparsed message if so desired.
