### PR TITLE
Better formatting code

### DIFF
--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -170,6 +170,9 @@ class SlackBot extends Adapter
             "#{label} (#{link})"
           else
             link
+    text = text.replace /&lt;/g, '<'
+    text = text.replace /&gt;/g, '>'
+    text = text.replace /&amp;/g, '&'
     text
 
   send: (envelope, messages...) ->

--- a/test/slack.coffee
+++ b/test/slack.coffee
@@ -57,6 +57,10 @@ describe 'Removing message formatting', ->
     foo = slackbot.removeFormatting 'foo'
     foo.should.equal 'foo'
 
+  it 'Should decode entities', ->
+    foo = slackbot.removeFormatting 'foo &gt; &amp; &lt; &gt;&amp;&lt;'
+    foo.should.equal 'foo > & < >&<'
+
   it 'Should change <@U1234> links to @name', ->
     foo = slackbot.removeFormatting 'foo <@U123> bar'
     foo.should.equal 'foo @name bar'
@@ -104,6 +108,10 @@ describe 'Removing message formatting', ->
   it 'Should remove formatting around <https> links with a substring label', ->
     foo = slackbot.removeFormatting 'foo <https://www.example.com|example.com> bar'
     foo.should.equal 'foo https://www.example.com bar'
+
+  it 'Should remove formatting around <https> links with a label containing entitles', ->
+    foo = slackbot.removeFormatting 'foo <https://www.example.com|label &gt; &amp; &lt;> bar'
+    foo.should.equal 'foo label > & < (https://www.example.com) bar'
 
   it 'Should remove formatting around <mailto> links', ->
     foo = slackbot.removeFormatting 'foo <mailto:name@example.com> bar'


### PR DESCRIPTION
This pull request improves our formatting code based on some great feedback from @kballard in #129. It:
- switches urls so they appear in brackets
- doesn't show the link label if the label is a substring of the URL (which is most links posted by people to slack)
- correctly decodes entities in messages
