### PR TITLE
Use require.main.require 'hubot' instead of require 'hubot'

### DIFF
--- a/src/hubot.coffee
+++ b/src/hubot.coffee
@@ -1,0 +1,18 @@
+# Because we have hubot in our devDependencies, if these dependencies are
+# installed, `require hubot` picks up the local version of hubot instead of the
+# one the robot is running from. This means that our emitted `TextMessage`s
+# won't trigger any `TextListener`s installed by scripts as that uses
+# `instanceof` (which doesn't handle duplicate definitions).
+#
+# As a workaround, we can use `require.main.require 'hubot'` to require 'hubot'
+# from the perspective of the "main" module. This will produce the correct
+# version of hubot under normal circumstances. This should only fail if hubot
+# is being used as a component of a larger application (even though it's not
+# designed to work that way).
+
+try
+  module.exports = require.main.require 'hubot'
+catch
+  # If that failed, we'll assume it's because it couldn't find the hubot module.
+  # In that event, let's just fall back to a normal require.
+  module.exports = require 'hubot'

--- a/src/listener.coffee
+++ b/src/listener.coffee
@@ -1,4 +1,4 @@
-{Listener} = require 'hubot'
+{Listener} = require './hubot'
 {SlackRawMessage, SlackBotMessage} = require './message'
 
 class SlackRawListener extends Listener

--- a/src/message.coffee
+++ b/src/message.coffee
@@ -1,4 +1,4 @@
-{Message, TextMessage} = require 'hubot'
+{Message, TextMessage} = require './hubot'
 
 # Hubot only started exporting Message in 2.11.0. Previous version do not export
 # this class. In order to remain compatible with older versions, we can pull the

--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -1,4 +1,4 @@
-{Robot, Adapter, EnterMessage, LeaveMessage, TopicMessage} = require 'hubot'
+{Robot, Adapter, EnterMessage, LeaveMessage, TopicMessage} = require './hubot'
 {SlackTextMessage, SlackRawMessage, SlackBotMessage} = require './message'
 {SlackRawListener, SlackBotListener} = require './listener'
 


### PR DESCRIPTION
Because we have hubot in our devDependencies, if these dependencies are 
installed, `require 'hubot'` will pick up the local version of hubot instead
of the one that the robot is running from. This means that our emitted
`TextMessage`s won't trigger any `TextListener`s installed by scripts (since
that uses `instanceof`).

As a workaround, use `require.main.require 'hubot'` instead, which requires
hubot from the context of the main module of the program. This should produce
the same module that the robot is running from (barring unusual edge cases).
If that fails, fall back to `require 'hubot'`, to handle cases such as running
the tests.
