### PR TITLE
Avoid our devDependencies when requiring 'hubot'

### DIFF
--- a/src/hubot.coffee
+++ b/src/hubot.coffee
@@ -1,0 +1,49 @@
+# Because we have hubot in our devDependencies, if these dependencies are
+# installed, `require hubot` picks up the local version of hubot instead of the
+# one the robot is running from. This means that our emitted `TextMessage`s
+# won't trigger any `TextListener`s installed by scripts as that uses
+# `instanceof` (which doesn't handle duplicate definitions).
+#
+# As a workaround, all requires of hubot are funneled through this module, and
+# here we can mess with our module.paths to ensure our devDependency doesn't
+# affect the loading of hubot.
+
+Path = require 'path'
+
+oldPaths = module.paths.splice(0) # make a copy
+modRoot = Path.dirname __dirname
+skipPath = Path.join modRoot, 'node_modules'
+if (idx = module.paths.indexOf skipPath) >= 0
+  module.paths.splice(idx, 1) # remove the path
+
+try
+  path = require.resolve 'hubot'
+catch
+  # If that failed, hopefully that means we're running tests.
+  # The alternative is we may be `npm link`ed in instead of properly installed
+  # and therefore cannot find the hubot.
+  # In that event, let's walk our parent modules until we find something outside
+  # our current directory.
+  mod = module
+  while mod = mod.parent
+    continue if mod.filename.slice(0, modRoot.length+1) == "#{modRoot}/"
+    break
+  if mod
+    # this is our first parent outside our module root
+    # Sadly, require.resolve isn't exposed on module.require.
+    # But we can hack it by swapping out our paths array.
+    module.paths = mod.paths
+    try
+      path = require.resolve 'hubot'
+    catch
+      # That failed. At this point, let's hope this is because we're running the
+      # test suite.
+finally
+  module.paths = oldPaths
+
+if path
+  module.exports = require path
+else
+  # Do a normal require with our original module paths. This will let our
+  # devDependencies have a shot at fulfilling the requirement.
+  module.exports = require 'hubot'

--- a/src/listener.coffee
+++ b/src/listener.coffee
@@ -1,4 +1,4 @@
-{Listener} = require 'hubot'
+{Listener} = require './hubot'
 {SlackRawMessage, SlackBotMessage} = require './message'
 
 class SlackRawListener extends Listener

--- a/src/message.coffee
+++ b/src/message.coffee
@@ -1,4 +1,4 @@
-{Message, TextMessage} = require 'hubot'
+{Message, TextMessage} = require './hubot'
 
 # Hubot only started exporting Message in 2.11.0. Previous version do not export
 # this class. In order to remain compatible with older versions, we can pull the

--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -1,4 +1,4 @@
-{Robot, Adapter, EnterMessage, LeaveMessage, TopicMessage} = require 'hubot'
+{Robot, Adapter, EnterMessage, LeaveMessage, TopicMessage} = require './hubot'
 {SlackTextMessage, SlackRawMessage, SlackBotMessage} = require './message'
 {SlackRawListener, SlackBotListener} = require './listener'
 


### PR DESCRIPTION
Because we have hubot in our devDependencies, if these dependencies are 
installed, `require 'hubot'` will pick up the local version of hubot instead
of the one that the robot is running from. This means that our emitted
`TextMessage`s won't trigger any `TextListener`s installed by scripts (since
that uses `instanceof`).

Implement a workaround that avoids loading 'hubot' from our local node_modules
folder if possible. It first tries finding 'hubot' without our node_modules,
and if that fails, it walks up the module parent tree until it finds a module
outside our directory tree and tries again from that spot. This means it works
correctly even if hubot-slack is installed with `npm link`. It falls back to a
normal `require 'hubot'` if all else fails, which allows the test suite to
work.

This is an alternative to PR #137.
