### PR TITLE
Add edited message handling. Should fix #143.

### DIFF
--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -115,6 +115,20 @@ class SlackBot extends Adapter
       if msg.subtype is 'bot_message'
         @robot.logger.debug "Received bot message: '#{text}' in channel: #{channel?.name}, from: #{user?.name}"
         @receive new SlackBotMessage user, text, rawText, msg
+
+      else if msg.subtype is 'message_changed'
+        rawText = msg.getBody()
+
+        # The content of the edited message
+        editedMessage = msg.message
+
+        text = editedMessage.text
+        user = @robot.brain.userForId editedMessage.user
+
+        @robot.logger.debug "Edited message: '#{text}' in channel: #{channel.name}, from: #{user.name}"
+
+        @receive new SlackTextMessage user, text, rawText, msg
+
       else
         @robot.logger.debug "Received raw message (subtype: #{msg.subtype})"
         @receive new SlackRawMessage user, text, rawText, msg

--- a/test/message.coffee
+++ b/test/message.coffee
@@ -66,6 +66,21 @@ describe 'Receiving a Slack message', ->
     msg.should.be.an.instanceOf SlackTextMessage
     msg.text.should.equal "Hello world\nattachment fallback\nsecond attachment fallback"
 
+  it 'should produce a SlackTextMessage in case of edited message', ->
+    @slackbot.message @makeMessage {
+      message: {
+        type: 'message',
+        user: @stubs.user.id,
+        text: 'Hello world',
+      },
+      subtype: 'message_changed',
+      hidden: true
+    }
+    @stubs.robot.received.should.have.length 1
+    msg = @stubs.robot.received[0]
+    msg.should.be.an.instanceOf SlackTextMessage
+    msg.text.should.equal "Hello world"
+
   it 'should save the raw message in the SlackTextMessage', ->
     @slackbot.message rawMsg = @makeMessage {
       subtype: 'file_share'


### PR DESCRIPTION
Edited messages get into the if statement at row 100 in slack.coffee

```
// msg.hidden = true; msg.user = null;

if msg.hidden or (not msg.text and not msg.attachments) 
              or msg.subtype is 'bot_message'
              or not msg.user or not channel
```

Even the content of the message is different, as it has a `message` property with the content of the edited message.

```
  type: 'message',
  message:
   { type: 'message',
     user: 'U0XXXU',
     text: 'Hello World',
     edited: { user: 'U0XXXU', ts: '1438982543.000000' },
     ts: '1438982539.000028' },
  subtype: 'message_changed',
```

I add a subtype statement to handle it as a regular `SlackTextMessage` instead of a `SlackRawMessage`.
