### PR TITLE
Add custom SlackResponse, so scripts can res.sendCustom for attachments

### DIFF
--- a/src/response.coffee
+++ b/src/response.coffee
@@ -1,0 +1,9 @@
+{Response} = require 'hubot'
+
+class SlackResponse extends Response
+
+  sendCustom: (data) ->
+    data.message = @envelope.message
+    @robot.adapter.customMessage data
+
+module.exports = SlackResponse

--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -1,6 +1,7 @@
 {Robot, Adapter, EnterMessage, LeaveMessage, TopicMessage} = require 'hubot'
 {SlackTextMessage, SlackRawMessage, SlackBotMessage} = require './message'
 {SlackRawListener, SlackBotListener} = require './listener'
+SlackResponse = require './response'
 
 SlackClient = require 'slack-client'
 Util = require 'util'
@@ -11,6 +12,7 @@ class SlackBot extends Adapter
 
   constructor: (robot) ->
     @robot = robot
+    @robot.Response = SlackResponse
 
   run: ->
     # Take our options from the environment, and set otherwise suitable defaults


### PR DESCRIPTION
m considering this more a proof of concept, rather than something that should be merged. This a different take on https://github.com/slackhq/hubot-slack/pull/233 . It's a much smaller diff since it's adding a new function, rather than changing the behavior of an existing one. Here's an example script that supports this with a fallback:

```
  robot.respond /PING$/i, (msg) ->
    if msg.sendCustom?
      msg.sendCustom {content: {color: 'good', text: "PONG"}}
    else
      msg.send "PONG"
```

This is better than https://github.com/slackhq/hubot-slack/pull/233 since it doesn't break the adapter's API contract. It also can be sniffed by script authors.

The only problem I have right now is the name. `custom` is way to generic I think. I was considering in https://github.com/github/hubot/issues/1036 to include the adapter's name in the function. I was thinking `sendSlackAttachment`, `sendSlackCustomMessage`, `sendSlackMessage`.

Two problems I see with that that:
- if you are doing slack-only bot, then you now have a ton of references to Slack in function names. You are doing slack, everything should be slack already. On the other hand, it's pretty clear what would need to change if you wanted to port to something else.
- it's actually the same Slack API call as `send`, it just has more options to it

cc https://github.com/github/hubot/issues/1036 for more background on supporting custom adapters & responses
