### PR TITLE
Send long messages as attachments with text

### DIFF
--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -206,7 +206,10 @@ class SlackBot extends Adapter
       @robot.logger.debug "Sending to #{envelope.room}: #{msg}"
 
       if msg.length <= SlackBot.MAX_MESSAGE_LENGTH
-        channel.send msg
+        if msg.length >= 700 || msg.split(/\n/).length > 5
+          @customMessage channel: envelope.room, content: {text: msg}
+        else
+          channel.send msg
 
       # If message is greater than MAX_MESSAGE_LENGTH, split it into multiple messages
       else
@@ -238,7 +241,11 @@ class SlackBot extends Adapter
 
             msg = msg.substring(breakIndex, msg.length)
 
-        channel.send m for m in submessages
+        for m in submessages
+          if msg.length >= 700 || msg.split(/\n/).length > 5
+            @customMessage channel: envelope.room, content: {text: msg}
+          else
+            channel.send msg
 
   reply: (envelope, messages...) ->
     @robot.logger.debug "Sending reply"

--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -242,10 +242,7 @@ class SlackBot extends Adapter
             msg = msg.substring(breakIndex, msg.length)
 
         for m in submessages
-          if msg.length >= 700 || msg.split(/\n/).length > 5
-            @customMessage channel: envelope.room, content: {text: msg}
-          else
-            channel.send msg
+          @customMessage channel: envelope.room, content: {text: m}
 
   reply: (envelope, messages...) ->
     @robot.logger.debug "Sending reply"


### PR DESCRIPTION
This prevents very long messages from flooding channels. It's triggered
by 700 characters or 5 lines of text. This was chosen because of the
attachment documentation at https://api.slack.com/docs/attachments saying:

> The content will automatically collapse if it contains 700+ characters or 5+ linebreaks, and will display a "Show more..." link to expand the content.

This would fix https://github.com/slackhq/hubot-slack/issues/17
