### PR TITLE
Change back quotes as Slack tends to change them on user input.

### DIFF
--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -168,6 +168,7 @@ class SlackBot extends Adapter
       (?:\|          # start of |label (optional)
         ([^>]+)      # label
       )?             # end of label
+      [‘“]*          # formatted single and double quote
       >              # closing angle bracket
     ///g, (m, type, link, label) =>
 
@@ -198,6 +199,8 @@ class SlackBot extends Adapter
     text = text.replace /&lt;/g, '<'
     text = text.replace /&gt;/g, '>'
     text = text.replace /&amp;/g, '&'
+    text = text.replace /‘/g, '\''
+    text = text.replace /“/g, '"'
     text
 
   send: (envelope, messages...) ->

--- a/test/slack.coffee
+++ b/test/slack.coffee
@@ -92,15 +92,25 @@ describe 'Removing message formatting', ->
     foo = @slackbot.removeFormatting 'foo <@U123|label> bar <#C123> <!channel> <https://www.example.com|label>'
     foo.should.equal 'foo label bar #general @channel label (https://www.example.com)'
 
-  it 'Should change formatted single quotes to normal', ->
+  it 'Should not change formatted quotes to normal by default', ->
+    foo = @slackbot.removeFormatting '‘bar‘“bar“'
+    foo.should.equal  '‘bar‘“bar“'
+
+  it 'Should change formatted single quotes to normal when enabled', ->
+    @slackbot.options =
+      replaceQuotes: true
     foo = @slackbot.removeFormatting '‘bar‘'
     foo.should.equal '\'bar\''
 
-  it 'Should change formatted double quotes to normal', ->
+  it 'Should change formatted double quotes to normal when enabled', ->
+    @slackbot.options =
+      replaceQuotes: true
     foo = @slackbot.removeFormatting '“bar“'
     foo.should.equal '"bar"'
 
-  it 'Should change formatted quotes to normal with other items in the text', ->
+  it 'Should change formatted quotes to normal with other items in the text when enabled', ->
+    @slackbot.options =
+      replaceQuotes: true
     foo = @slackbot.removeFormatting 'foo <@U123|label> bar <#C123> “bar“ <!channel> <https://www.example.com|label>'
     foo.should.equal 'foo label bar #general "bar" @channel label (https://www.example.com)'
 

--- a/test/slack.coffee
+++ b/test/slack.coffee
@@ -92,6 +92,18 @@ describe 'Removing message formatting', ->
     foo = @slackbot.removeFormatting 'foo <@U123|label> bar <#C123> <!channel> <https://www.example.com|label>'
     foo.should.equal 'foo label bar #general @channel label (https://www.example.com)'
 
+  it 'Should change formatted single quotes to normal', ->
+    foo = @slackbot.removeFormatting '‘bar‘'
+    foo.should.equal '\'bar\''
+
+  it 'Should change formatted double quotes to normal', ->
+    foo = @slackbot.removeFormatting '“bar“'
+    foo.should.equal '"bar"'
+
+  it 'Should change formatted quotes to normal with other items in the text', ->
+    foo = @slackbot.removeFormatting 'foo <@U123|label> bar <#C123> “bar“ <!channel> <https://www.example.com|label>'
+    foo.should.equal 'foo label bar #general "bar" @channel label (https://www.example.com)'
+
 describe 'Send Messages', ->
   it 'Should send multiple messages', ->
     sentMessages = @slackbot.send {room: 'general'}, 'one', 'two', 'three'


### PR DESCRIPTION
Some hubot plugins (like [hubot-trello](https://github.com/hubot-scripts/hubot-trello) match on quotes and they fail to work together with Slack as when a user enters ' Slack changes it to ‘ and the same happens to double quotes. 

I think it is best to replace those characters in the removeFormatting method but this is just a naive first try from me so please point out if I made any mistakes or the whole assumption is wrong. 
