### PR TITLE
Adding new DM creation to customMessage when none previously existed.

### DIFF
--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -39,6 +39,7 @@ class SlackBot extends Adapter
     @client.on 'close', @.clientClose
     @client.on 'message', @.message
     @client.on 'userChange', @.userChange
+    @client.on 'raw_message', @.rawMessage
     @robot.brain.on 'loaded', @.brainLoaded
 
     @robot.on 'slack-attachment', @.customMessage
@@ -108,6 +109,7 @@ class SlackBot extends Adapter
       @client.removeListener 'close', @.clientClose
       @client.removeListener 'message', @.message
       @client.removeListener 'userChange', @.userChange
+      @client.removeListener 'raw_message', @.rawMessage
       process.exit 1
     else
       @robot.logger.info 'Slack client closed, waiting for reconnect'
@@ -170,6 +172,17 @@ class SlackBot extends Adapter
         text = "#{@robot.name} #{text}"
 
       @receive new SlackTextMessage user, text, rawText, msg
+
+  rawMessage: (msg) =>
+    # We can switch the various msg.types that SlackRawMessage doesn't handle for us here, such as channel_create and reaction.
+    switch msg.type
+      when "channel_created"
+        if msg.type == "channel_created"
+          user = @robot.brain.userForId msg.channel.creator
+          # populate event data
+          newChannel = message: msg, user: user
+          @robot.emit 'channelCreated', newChannel
+      # Additional msg.types to be added.
 
   removeFormatting: (text) ->
     # https://api.slack.com/docs/formatting

--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -293,7 +293,6 @@ class SlackBot extends Adapter
 
     channel = @client.getChannelGroupOrDMByName channelName
     channel = @client.getChannelGroupOrDMByID(channelName) unless channel
-    return unless channel
 
     msg = {}
     msg.attachments = data.attachments || data.content
@@ -310,6 +309,14 @@ class SlackBot extends Adapter
         msg.icon_emoji = data.icon_emoji
     else
       msg.as_user = true
+
+    if not channel and @client.getUserByName(channelName)
+      user_id = @client.getUserByName(channelName).id
+      @client.openDM user_id, =>
+        channel = @client.getChannelGroupOrDMByName channelName
+        channel = @client.getChannelGroupOrDMByID(channelName) unless channel
+        channel.postMessage msg
+      return
 
     channel.postMessage msg
 


### PR DESCRIPTION
This attempts to extend #168 to customMessages, and was generated in response to and fixes issue #256.

Previously checks for existing DM.id were added to .send in #168, however .customMessage still suffered from the issue and would only send a DM if one previously existed.  This change allows messages to be sent to a user via direct message if no previous direct messages existed when using .customMessage and now aligns behavior with .send.

Note: If there's a better, cleaner, way to accomplish this please let me know.  It's my first crack at contributing to a project.
