### PR TITLE
Mark messages not from public channels as 'private'

### DIFF
--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -148,15 +148,15 @@ class SlackBot extends Adapter
     # Test for enter/leave messages
     if msg.subtype is 'channel_join' or msg.subtype is 'group_join'
       @robot.logger.debug "#{user.name} has joined #{channel.name}"
-      @receive new EnterMessage user
+      message = new EnterMessage user
 
     else if msg.subtype is 'channel_leave' or msg.subtype is 'group_leave'
       @robot.logger.debug "#{user.name} has left #{channel.name}"
-      @receive new LeaveMessage user
+      message = new LeaveMessage user
 
     else if msg.subtype is 'channel_topic' or msg.subtype is 'group_topic'
       @robot.logger.debug "#{user.name} set the topic in #{channel.name} to #{msg.topic}"
-      @receive new TopicMessage user, msg.topic, msg.ts
+      message = new TopicMessage user, msg.topic, msg.ts
 
     else
       # Build message text to respond to, including all attachments
@@ -169,7 +169,12 @@ class SlackBot extends Adapter
       if msg.getChannelType() == 'DM'
         text = "#{@robot.name} #{text}"
 
-      @receive new SlackTextMessage user, text, rawText, msg
+      message =  new SlackTextMessage user, text, rawText, msg
+
+    channelType = msg.rawMessage.getChannelType()
+    message.private = if channelType is "Channel" then false else true
+
+    @receive message
 
   removeFormatting: (text) ->
     # https://api.slack.com/docs/formatting


### PR DESCRIPTION
This lets scripts and middleware know if they were said in private channels
 or direct messages, so they can choose to not log or otherwise output
information that was said in the channel.

Here's an example:

``` coffeescript
module.exports = (robot) ->
  robot.respond /PUBLICPING$/i, onlyPublic: true, (msg) ->
    msg.send "PUBLIC PONG"

  robot.listenerMiddleware (context, next, done) ->
    return next() unless context.listener.options?.onlyPublic

    if context.response.message.private
      done()
    else
      next()
```

For prior art, hubot's campfire adapter uses this for [locked messages](https://github.com/github/hubot/blob/master/src/adapters/campfire.coffee#L73), which are messages that aren't logged. It's not documented at the moment though.
