### PR TITLE
Allow commands to be run with alias/name prefix in direct messages

### DIFF
--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -168,8 +168,8 @@ class SlackBot extends Adapter
       # If this is a DM, pretend it was addressed to us (prepend the robot name).
       # But do it only if the text does not already start with the name, or the alias.
       if msg.getChannelType() == 'DM'
-        nameRegex = "@?#{robot.name}"
-        prefixRegex = if robot.alias then "(#{nameRegex}|#{robot.alias})" else "#{nameRegex}"
+        nameRegex = "@?#{@robot.name}"
+        prefixRegex = if @robot.alias then "(#{nameRegex}|#{@robot.alias})" else "#{nameRegex}"
         text = "#{@robot.name} #{text}" unless text.match (new RegExp("^#{prefixRegex}", 'i'))
 
       @receive new SlackTextMessage user, text, rawText, msg

--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -165,9 +165,12 @@ class SlackBot extends Adapter
 
       @robot.logger.debug "Received message: '#{text}' in channel: #{channel.name}, from: #{user.name}"
 
-      # If this is a DM, pretend it was addressed to us
+      # If this is a DM, pretend it was addressed to us (prepend the robot name).
+      # But do it only if the text does not already start with the name, or the alias.
       if msg.getChannelType() == 'DM'
-        text = "#{@robot.name} #{text}"
+        nameRegex = "@?#{robot.name}"
+        prefixRegex = if robot.alias then "(#{nameRegex}|#{robot.alias})" else "#{nameRegex}"
+        text = "#{@robot.name} #{text}" unless text.match (new RegExp("^#{prefixRegex}", 'i'))
 
       @receive new SlackTextMessage user, text, rawText, msg
 


### PR DESCRIPTION
From direct messages to hubot, commands like `help` work fine when they are not prefixed by anything else. However, people are used to prepending the hubot name, or the alias to run the commands in channels, and if they do the same in DM's, the commands don't work currently. 

This pull request makes command invocation consistent in both channels and DM's (i.e. this enables `hubot help` or `:help` (assuming `HUBOT_ALIAS` is set to `:`), in addition to just `help`)

For reference, other adapters implement similar [functionality](https://github.com/markstory/hubot-xmpp/issues/85#issuecomment-142391307).
