### PR TITLE
Linkify names in messages sent via customMessage(), plus other improvements for the method

### DIFF
--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -311,6 +311,9 @@ class SlackBot extends Adapter
     else
       msg.as_user = true
 
+    # linkify channel and user names
+    msg.link_names = 1
+
     channel.postMessage msg
 
 # Export class for unit tests


### PR DESCRIPTION
If a username or channel name is part of a hubot message (via `customMessage()`) , slack does not linkify it currently. Slack's [postMessage](https://api.slack.com/methods/chat.postMessage) endpoint (which the hubot method is using) supports it though, via the `link_names` option. Not sure why it was not enabled initially for hubot, but we have been using this for a week now and I have not noticed any issues.

Also added a new event `slack.customMessage` for triggering `customMessage()`. That method can be used to send text without any attachments too, as in:

```
robot.emit slack.customMessage, {room: "deploy", text: "Test run #<http://example.com/tests/run/1234|1234> failed"}
```

In fact, this has been the only way I have been able to use formatted url links in hubot messages, without resorting to attachments (which adds a vertical bar on the left and occupies more space. Just using `pretext` from the attachments array also does not work). The other `send()` function does not support formatted links, as discussed [elsewhere](https://github.com/slackhq/hubot-slack/issues/114). So it makes sense to add another event for triggering `customMessage()` -- it's a minor change anyway.

Also added some logging statements to help with debugging.
