### PR TITLE
Add proxy support based on new Slack SDK v3

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -1,4 +1,4 @@
 SlackBot = require './src/bot'
 
 exports.use = (robot) ->
-  new SlackBot robot, token: process.env.HUBOT_SLACK_TOKEN
+  new SlackBot robot, token: process.env.HUBOT_SLACK_TOKEN, proxyUrl: process.env.HUBOT_SLACK_PROXY

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -2,7 +2,7 @@
 SlackFormatter = require './formatter'
 _ = require 'lodash'
 wsTransport = require('@slack/client/lib/clients/transports/ws')
-proxiedRequestTransport = require('@slack/client/lib/clients/transports/request.js').proxiedRequestTransport
+proxiedRequestTransport = require('@slack/client/lib/clients/transports/request').proxiedRequestTransport
 
 SLACK_CLIENT_OPTIONS =
   dataStore: new MemoryDataStore()
@@ -17,7 +17,7 @@ class SlackClient
     if options.proxyUrl?
       options['socketFn'] = (socketUrl) ->
         return wsTransport socketUrl, { proxyURL: options.proxyUrl, proxyUrl: options.proxyUrl }
-      options['transport'] = proxiedRequestTransport(options.proxyUrl)
+      options['transport'] = proxiedRequestTransport options.proxyUrl
 
     # RTM is the default communication client
     @rtm = new RtmClient options.token, options

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -1,6 +1,9 @@
 {RtmClient, WebClient, MemoryDataStore} = require '@slack/client'
 SlackFormatter = require './formatter'
 _ = require 'lodash'
+wsTransport = require('@slack/client/lib/clients/transports/ws')
+proxiedRequestTransport = require('@slack/client/lib/clients/transports/request.js').proxiedRequestTransport
+requestTransport = require('@slack/client/lib/clients/transports/request.js').requestTransport
 
 SLACK_CLIENT_OPTIONS =
   dataStore: new MemoryDataStore()
@@ -10,6 +13,12 @@ class SlackClient
   
   constructor: (options) ->
     _.merge SLACK_CLIENT_OPTIONS, options
+    
+    # Configure proxy url if set
+    if options.proxyUrl?
+      options['socketFn'] = (socketUrl) ->
+        return wsTransport socketUrl, { proxyURL: options.proxyUrl, proxyUrl: options.proxyUrl }
+      options['transport'] = proxiedRequestTransport(options.proxyUrl)
 
     # RTM is the default communication client
     @rtm = new RtmClient options.token, options

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -3,7 +3,6 @@ SlackFormatter = require './formatter'
 _ = require 'lodash'
 wsTransport = require('@slack/client/lib/clients/transports/ws')
 proxiedRequestTransport = require('@slack/client/lib/clients/transports/request.js').proxiedRequestTransport
-requestTransport = require('@slack/client/lib/clients/transports/request.js').requestTransport
 
 SLACK_CLIENT_OPTIONS =
   dataStore: new MemoryDataStore()


### PR DESCRIPTION
This will add a proxy support using wsTransport for ws/wss, proxiedRequestTransport for http/https. 
Proxy url can be configured by setting the environment variable `HUBOT_SLACK_PROXY`.
