### PR TITLE
document changes in hubot-slack 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,41 @@ need to upgrade:
 - Once you're happy it works, disable the old hubot integration from
   https://my.slack.com/services
 
+## Upgrading from version 3 or earlier of hubot-slack
+
+Version 4 of the hubot-slack adapter uses a more recent version of
+`node-slack-sdk`.  As a result, there are some syntax changes within Hubot:
+
+1. Before version 4, `msg.message.room` would return the name of the room
+(e.g. `general`).  `msg.message.room` now returns a room identifier
+(e.g. `C03NM270D`).  If you need to translate the room id to a room name,
+you can look it up with the client:
+
+    ```coffeescript
+      robot.respond /what room am i in\?/i, (msg) ->
+        room = msg.message.room
+        roomName = robot.adapter.client.rtm.dataStore.getChannelById(room).name
+        msg.send roomName
+    ```
+
+2. Version 3 of hubot-slack supported attachments by emitting a
+`slack.attachment` event.  In version 4, you use `msg.send`, passing an object
+with an `attachments` array:
+
+    ```coffeescript
+      robot.respond /send attachments/i, (msg) ->
+        msg.send(
+          attachments: [
+            {
+              text: '*error*: something bad happened'
+              fallback: 'error: something bad happened'
+              color: 'danger'
+              mrkdwn_in: ['text']
+            }
+          ]
+        )
+    ```
+
 ## Configuration
 
 This adapter uses the following environment variables:


### PR DESCRIPTION
- [x] I've read and understood the [Contributing guidelines](./CONTRIBUTING.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
- [x] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
- [x] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
- [x] I've written tests to cover the new code and functionality included in this PR.
- [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).
#### PR Summary

There are changes in hubot-slack 4 that won't work with some existing Hubot scripts.  I added some documentation to the README describing the new syntax.  (There was also a change to `robot.messageRoom`, but #346 should add backwards compatibility.)
#### Related Issues

None.
#### Test strategy
1. The following script will send a room name in hubot-slack 3 but a room id in hubot-slack 4:
   
   ``` coffeescript
     robot.respond /what room am i in\?/i, (msg) ->
       room = msg.message.room
       msg.send room
   ```
2. The following script will send an attachment in hubot-slack 3 but send nothing in hubot-slack 4:
   
   ``` coffeescript
     robot.respond /send attachments/i, (msg) ->
       robot.emit 'slack.attachment',
         message: msg.message,
         content:
             text: '*error*: something bad happened'
             fallback: 'error: something bad happened'
             color: 'danger'
             mrkdwn_in: ['text']
   ```
