### PR TITLE
Renaming a function that has a name collision with the base class

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-slack",
-  "version": "4.1.0",
+  "version": "4.2.1",
   "description": "A Slack adapter for hubot",
   "main": "./slack",
   "scripts": {
@@ -28,7 +28,7 @@
     "lodash": "^3.10.1"
   },
   "devDependencies": {
-    "hubot": "~2.11",
+    "hubot": "~2.19",
     "coffee-coverage": "^1.0.1",
     "coffee-script": "~1.7.1",
     "coveralls": "^2.11.9",

--- a/src/bot.coffee
+++ b/src/bot.coffee
@@ -180,7 +180,7 @@ class SlackBot extends Adapter
 
       when 'channel_topic', 'group_topic'
         @robot.logger.debug "#{user.name} set the topic in #{channel.name} to #{topic}"
-        @receive new TopicMessage user, message.setTopic, message.ts
+        @receive new TopicMessage user, message.topic, message.ts
 
       else        
         @robot.logger.debug "Received message: '#{text}' in channel: #{channel.name}, subtype: #{subtype}"

--- a/src/bot.coffee
+++ b/src/bot.coffee
@@ -133,7 +133,7 @@ class SlackBot extends Adapter
   ###
   Hubot is setting the Slack channel topic
   ###
-  topic: (envelope, strings...) ->
+  setTopic: (envelope, strings...) ->
     return if envelope.room[0] is 'D' # ignore DMs
 
     @client.setTopic envelope.room, strings.join "\n"
@@ -180,7 +180,7 @@ class SlackBot extends Adapter
 
       when 'channel_topic', 'group_topic'
         @robot.logger.debug "#{user.name} set the topic in #{channel.name} to #{topic}"
-        @receive new TopicMessage user, message.topic, message.ts
+        @receive new TopicMessage user, message.setTopic, message.ts
 
       else        
         @robot.logger.debug "Received message: '#{text}' in channel: #{channel.name}, subtype: #{subtype}"

--- a/test/bot.coffee
+++ b/test/bot.coffee
@@ -96,11 +96,11 @@ describe 'Reply to Messages', ->
 
 describe 'Setting the channel topic', ->
   it 'Should set the topic in channels', ->
-    @slackbot.topic {room: @stubs.channel.id}, 'channel'
+    @slackbot.setTopic {room: @stubs.channel.id}, 'channel'
     @stubs._topic.should.equal 'channel'
 
   it 'Should NOT set the topic in DMs', ->
-    @slackbot.topic {room: 'D1232'}, 'DM'
+    @slackbot.setTopic {room: 'D1232'}, 'DM'
     should.not.exists(@stubs._topic)
 
 describe 'Receiving an error event', ->


### PR DESCRIPTION
So, it turns out that the `robot` base class has an event handler named `topic`, and the `bot` derived class overrides that into a different method signature, and this breaks things.
https://dev4slack.slack.com/archives/sdk-hubot-slack/p1478282324000005 and _ff._