### PR TITLE
Improve the SlackFormatter to add support for subteams and fix inconsistencies

### DIFF
--- a/src/formatter.coffee
+++ b/src/formatter.coffee
@@ -25,13 +25,13 @@ class SlackFormatter
       switch type
 
         when '@'
-          if label then return label
+          if label then return "@#{label}"
           user = @dataStore.getUserById link
           if user
             return "@#{user.name}"
 
         when '#'
-          if label then return label
+          if label then return "\##{label}"
           channel = @dataStore.getChannelById link
           if channel
             return "\##{channel.name}"
@@ -39,6 +39,9 @@ class SlackFormatter
         when '!'
           if link in MESSAGE_RESERVED_KEYWORDS
             return "@#{link}"
+          else if label
+            return label
+          return m
 
         else
           link = link.replace /^mailto:/, ''

--- a/test/formatter.coffee
+++ b/test/formatter.coffee
@@ -20,17 +20,17 @@ describe 'links()', ->
     foo = @formatter.links 'foo <@U123> bar'
     foo.should.equal 'foo @name bar'
 
-  it 'Should change <@U123|label> links to label', ->
+  it 'Should change <@U123|label> links to @label', ->
     foo = @formatter.links 'foo <@U123|label> bar'
-    foo.should.equal 'foo label bar'
+    foo.should.equal 'foo @label bar'
 
   it 'Should change <#C123> links to #general', ->
     foo = @formatter.links 'foo <#C123> bar'
     foo.should.equal 'foo #general bar'
 
-  it 'Should change <#C123|label> links to label', ->
+  it 'Should change <#C123|label> links to #label', ->
     foo = @formatter.links 'foo <#C123|label> bar'
-    foo.should.equal 'foo label bar'
+    foo.should.equal 'foo #label bar'
 
   it 'Should change <!everyone> links to @everyone', ->
     foo = @formatter.links 'foo <!everyone> bar'
@@ -47,6 +47,18 @@ describe 'links()', ->
   it 'Should change <!here> links to @here', ->
     foo = @formatter.links 'foo <!here> bar'
     foo.should.equal 'foo @here bar'
+
+  it 'Should change <!subteam^S123|@subteam> links to @subteam', ->
+    foo = @formatter.links 'foo <!subteam^S123|@subteam> bar'
+    foo.should.equal 'foo @subteam bar'
+
+  it 'Should change <!foobar|hello> links to hello', ->
+    foo = @formatter.links 'foo <!foobar|hello> bar'
+    foo.should.equal 'foo hello bar'
+
+  it 'Should leave <!foobar> links as-is when no label is provided', ->
+    foo = @formatter.links 'foo <!foobar> bar'
+    foo.should.equal 'foo <!foobar> bar'
 
   it 'Should remove formatting around <http> links', ->
     foo = @formatter.links 'foo <http://www.example.com> bar'
@@ -82,7 +94,7 @@ describe 'links()', ->
 
   it 'Should change multiple links at once', ->
     foo = @formatter.links 'foo <@U123|label> bar <#C123> <!channel> <https://www.example.com|label>'
-    foo.should.equal 'foo label bar #general @channel label (https://www.example.com)'
+    foo.should.equal 'foo @label bar #general @channel label (https://www.example.com)'
 
 
 


### PR DESCRIPTION
* [x] I've read and understood the [Contributing guidelines](./CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
* [x] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [x] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [x] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary
> The formatter was producing links for channels and usernames with preceeding @ and #. Also added support for parsing subteam links and future proofed for other link types that are currently unknown

#### Related Issues
> e.g. Fixes #288 and closes #366 

#### Test strategy
> Modify channel and user name tests to change the expected output where appropriate (that is, always ensure channels are proceeded by # and usernames are proceeded by @)
> Added tests for subteam links
> Added tests for parsing unknown link types