### PR TITLE
Handle user_change event properly

### DIFF
--- a/src/bot.coffee
+++ b/src/bot.coffee
@@ -209,9 +209,9 @@ class SlackBot extends Adapter
       @robot.logger.error "Can't fetch users"
       return
 
-    @userChange member for member in res.members
+    @changeUser member for member in res.members
 
-  userChange: (user) =>
+  changeUser: (user) =>
     return unless user
     newUser =
       id: user.id
@@ -231,5 +231,12 @@ class SlackBot extends Adapter
           newUser[key] = value
     delete @robot.brain.data.users[user.id]
     @robot.brain.userForId user.id, newUser
+
+  ###
+  Handle user_change event
+  ###
+  userChange: (event) =>
+    return unless event.type == 'user_change'
+    @changeUser event.user
 
 module.exports = SlackBot

--- a/test/bot.coffee
+++ b/test/bot.coffee
@@ -357,3 +357,27 @@ describe 'Users data', ->
   it 'Should detect wrong response from web api', ->
     @slackbot.loadUsers(null, @stubs.wrongResponseUsersList)
     should.equal @slackbot.robot.brain.data.users[@stubs.user.id], undefined
+
+  it 'Should handle user_changed events as envisioned', ->
+    payload = {
+      type: 'user_change',
+      user: @stubs.user
+    }
+    @slackbot.userChange payload
+
+    user = @slackbot.robot.brain.data.users[@stubs.user.id]
+    should.equal user.id, @stubs.user.id
+    should.equal user.name, @stubs.user.name
+    should.equal user.real_name, @stubs.user.real_name
+    should.equal user.email_address, @stubs.user.profile.email
+    should.equal user.slack.misc, @stubs.user.misc
+
+  it 'Should ignore user_changed events that are invalid', ->
+    payload = {
+      type: 'emoji_changed',
+      user: @stubs.user
+    }
+    @slackbot.userChange payload
+
+    user = @slackbot.robot.brain.data.users[@stubs.user.id]
+    should.equal user, undefined

--- a/test/bot.coffee
+++ b/test/bot.coffee
@@ -258,7 +258,7 @@ describe 'Robot.react', ->
 
 describe 'Users data', ->
   it 'Should add a user data', ->
-    @slackbot.userChange(@stubs.user)
+    @slackbot.changeUser(@stubs.user)
 
     user = @slackbot.robot.brain.data.users[@stubs.user.id]
     should.equal user.id, @stubs.user.id
@@ -268,7 +268,7 @@ describe 'Users data', ->
     should.equal user.slack.misc, @stubs.user.misc
 
   it 'Should add a user data (user with no profile)', ->
-    @slackbot.userChange(@stubs.usernoprofile)
+    @slackbot.changeUser(@stubs.usernoprofile)
 
     user = @slackbot.robot.brain.data.users[@stubs.usernoprofile.id]
     should.equal user.id, @stubs.usernoprofile.id
@@ -278,7 +278,7 @@ describe 'Users data', ->
     (user).should.not.have.ownProperty('email_address')
 
   it 'Should add a user data (user with no email in profile)', ->
-    @slackbot.userChange(@stubs.usernoemail)
+    @slackbot.changeUser(@stubs.usernoemail)
 
     user = @slackbot.robot.brain.data.users[@stubs.usernoemail.id]
     should.equal user.id, @stubs.usernoemail.id
@@ -288,7 +288,7 @@ describe 'Users data', ->
     (user).should.not.have.ownProperty('email_address')
 
   it 'Should modify a user data', ->
-    @slackbot.userChange(@stubs.user)
+    @slackbot.changeUser(@stubs.user)
 
     user = @slackbot.robot.brain.data.users[@stubs.user.id]
     should.equal user.id, @stubs.user.id
@@ -308,7 +308,7 @@ describe 'Users data', ->
       client:
         client
 
-    @slackbot.userChange(modified_user)
+    @slackbot.changeUser(modified_user)
 
     user = @slackbot.robot.brain.data.users[@stubs.user.id]
     should.equal user.id, @stubs.user.id
@@ -319,7 +319,7 @@ describe 'Users data', ->
     should.equal user.slack.client, undefined
 
   it 'Should ignore user data which is undefined', ->
-    @slackbot.userChange(undefined)
+    @slackbot.changeUser(undefined)
     users = @slackbot.robot.brain.data.users
     should.equal Object.keys(users).length, 0
 


### PR DESCRIPTION
* [x] I've read and understood the [Contributing guidelines](./CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
* [x] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [x] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [x] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary
The method `SlackBot::userChanged` handles the `user_change` event, however it expects a `user` object and this event's [payload](https://api.slack.com/events/user_change) is something like the following:

```
{ type: 'user_change',
  user: 
    { id: 'U0123ABCD',
      team_id: 'T0123ABCD',
      name: 'will',
      ... },
   ... }
```

The changes below rename the current `SlackBot::userChange` to `changeUser` and add a new `userChange` that extracts the user object from the event and passes it to `changeUser`. I felt that "change user" better matched the intent of the method, but given that this has already been released you may not wish to refactor in this way...

#### Related Issues
Fixes #391

#### Test strategy
Updates relevant "Users data" tests.

/cc @aoberoi (as you reviewed #381)