### PR TITLE
Fix CoC and Contribution guideline links on issues

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,5 +1,5 @@
-* [ ] I've read and understood the [Contributing guidelines](./CONTRIBUTING.md) and have done my best effort to follow them.
-* [ ] I've read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
+* [ ] I've read and understood the [Contributing guidelines](https://github.com/slackapi/hubot-slack/blob/master/CONTRIBUTING.md) and have done my best effort to follow them.
+* [ ] I've read and agree to the [Code of Conduct](https://github.com/slackapi/hubot-slack/blob/master/CODE_OF_CONDUCT.md).
 * [ ] I've searched for any related issues and avoided creating a duplicate issue.
 
 #### Description


### PR DESCRIPTION
* [x] I've read and understood the [Contributing guidelines](./CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
* [x] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [x] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary
Those links are currently broken, see here for example: https://github.com/slackapi/hubot-slack/issues/393

#### Test strategy
Merge this and hopefully the next issue has working links. 