### PR TITLE
enhances SlackBot.userChange() to take either a user or event

### DIFF
--- a/src/bot.coffee
+++ b/src/bot.coffee
@@ -211,8 +211,11 @@ class SlackBot extends Adapter
 
     @userChange member for member in res.members
 
-  userChange: (user) =>
-    return unless user
+  # when invoked as an event handler, this method takes an event. but when invoked from loadUsers,
+  # this method takes a user
+  userChange: (event_or_user) =>
+    return unless event_or_user
+    user = if event_or_user.type == 'user_change' then event_or_user.user else event_or_user
     newUser =
       id: user.id
       name: user.name

--- a/test/bot.coffee
+++ b/test/bot.coffee
@@ -299,20 +299,22 @@ describe 'Users data', ->
 
     client = new SlackClient {token: 'xoxb-faketoken'}, @stubs.robot
 
-    modified_user =
-      id: @stubs.user.id
-      name: 'modified_name'
-      real_name: @stubs.user.real_name
-      profile:
-        email: @stubs.user.profile.email
-      client:
-        client
+    user_change_event =
+      type: 'user_change'
+      user:
+        id: @stubs.user.id
+        name: 'modified_name'
+        real_name: @stubs.user.real_name
+        profile:
+          email: @stubs.user.profile.email
+        client:
+          client
 
-    @slackbot.userChange(modified_user)
+    @slackbot.userChange(user_change_event)
 
     user = @slackbot.robot.brain.data.users[@stubs.user.id]
     should.equal user.id, @stubs.user.id
-    should.equal user.name, modified_user.name
+    should.equal user.name, user_change_event.user.name
     should.equal user.real_name, @stubs.user.real_name
     should.equal user.email_address, @stubs.user.profile.email
     should.equal user.slack.misc, undefined


### PR DESCRIPTION
fixes #391

* [x] I've read and understood the [Contributing guidelines](./CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
* [x] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [x] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [x] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).