### PR TITLE
Return rawText and rawMessage objects

### DIFF
--- a/src/bot.coffee
+++ b/src/bot.coffee
@@ -149,7 +149,7 @@ class SlackBot extends Adapter
   Message received from Slack
   ###
   message: (message) =>
-    {text, rawText, user, channel, subtype, topic, bot} = message
+    {text, rawText, returnRawText, user, channel, subtype, topic, bot} = message
 
     return if user && (user.id == @self.id) # Ignore anything we sent, or anything from an unknown user
     return if bot && (bot.id == @self.bot_id) # Ignore anything we sent, or anything from an unknown bot
@@ -174,7 +174,10 @@ class SlackBot extends Adapter
 
       when 'message', 'bot_message'
         @robot.logger.debug "Received message: '#{text}' in channel: #{channel.name}, from: #{user.name}"
-        textMessage = new SlackTextMessage(user, text, rawText, message)
+        if returnRawText
+          textMessage = new SlackTextMessage(user, text, rawText, message)
+        else
+          textMessage = new TextMessage(user, text, message.ts)
         textMessage.thread_ts = message.thread_ts
         @receive textMessage
 

--- a/src/bot.coffee
+++ b/src/bot.coffee
@@ -2,6 +2,7 @@
 
 SlackClient = require './client'
 ReactionMessage = require './reaction-message'
+SlackTextMessage = require './slack-message'
 
 # Public: Adds a Listener for ReactionMessages with the provided matcher,
 # options, and callback
@@ -148,7 +149,7 @@ class SlackBot extends Adapter
   Message received from Slack
   ###
   message: (message) =>
-    {text, user, channel, subtype, topic, bot} = message
+    {text, rawText, user, channel, subtype, topic, bot} = message
 
     return if user && (user.id == @self.id) # Ignore anything we sent, or anything from an unknown user
     return if bot && (bot.id == @self.bot_id) # Ignore anything we sent, or anything from an unknown bot
@@ -173,7 +174,7 @@ class SlackBot extends Adapter
 
       when 'message', 'bot_message'
         @robot.logger.debug "Received message: '#{text}' in channel: #{channel.name}, from: #{user.name}"
-        textMessage = new TextMessage(user, text, message.ts)
+        textMessage = new SlackTextMessage(user, text, rawText, message)
         textMessage.thread_ts = message.thread_ts
         @receive textMessage
 

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -25,6 +25,8 @@ class SlackClient
     # Track listeners for easy clean-up
     @listeners = []
 
+    @returnRawText = !options.noRawText
+
   ###
   Open connection to the Slack RTM API
   ###
@@ -44,6 +46,7 @@ class SlackClient
         {user, channel, bot_id} = message
 
         message.rawText = message.text
+        message.returnRawText = @returnRawText
         message.text = @format.incoming(message)
         message.user = @rtm.dataStore.getUserById(user) if user
         message.bot = @rtm.dataStore.getBotById(bot_id) if bot_id

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -43,6 +43,7 @@ class SlackClient
       @rtm.on name, (message) =>
         {user, channel, bot_id} = message
 
+        message.rawText = message.text
         message.text = @format.incoming(message)
         message.user = @rtm.dataStore.getUserById(user) if user
         message.bot = @rtm.dataStore.getBotById(bot_id) if bot_id

--- a/src/slack-message.coffee
+++ b/src/slack-message.coffee
@@ -1,0 +1,13 @@
+{TextMessage} = require.main.require 'hubot'
+
+class SlackTextMessage extends TextMessage
+  # Represents a TextMessage created from the Slack adapter
+  #
+  # user       - The User object
+  # text       - The parsed message text
+  # rawText    - The unparsed message text
+  # rawMessage - The Slack Message object
+  constructor: (@user, @text, @rawText, @rawMessage) ->
+    super @user, @text, @rawMessage.ts
+
+module.exports = SlackTextMessage

--- a/test/bot.coffee
+++ b/test/bot.coffee
@@ -130,7 +130,8 @@ describe 'Handling incoming messages', ->
       user: @stubs.user,
       channel: @stubs.channel,
       text: 'foo http://www.example.com bar',
-      rawText: 'foo <http://www.example.com> bar'
+      rawText: 'foo <http://www.example.com> bar',
+      returnRawText: true
     }
     @slackbot.message messageData
     should.equal (@stubs._received instanceof SlackTextMessage), true
@@ -203,7 +204,7 @@ describe 'Handling incoming messages', ->
     should.equal (@stubs._received instanceof CatchAllMessage), true
 
   it 'Should not crash with bot messages', ->
-    @slackbot.message { subtype: 'bot_message', bot: @stubs.bot, channel: @stubs.channel, text: 'Pushing is the answer' }
+    @slackbot.message { subtype: 'bot_message', bot: @stubs.bot, channel: @stubs.channel, text: 'Pushing is the answer', returnRawText: true }
     should.equal (@stubs._received instanceof SlackTextMessage), true
 
   it 'Should ignore messages it sent itself', ->

--- a/test/bot.coffee
+++ b/test/bot.coffee
@@ -2,6 +2,7 @@ should = require 'should'
 {Adapter, TextMessage, EnterMessage, LeaveMessage, TopicMessage, Message, CatchAllMessage, Robot, Listener} = require.main.require 'hubot'
 ReactionMessage = require '../src/reaction-message'
 SlackClient = require '../src/client'
+SlackTextMessage = require '../src/slack-message'
 
 describe 'Adapter', ->
   it 'Should initialize with a robot', ->
@@ -123,6 +124,20 @@ describe 'Handling incoming messages', ->
     @slackbot.message {text: 'foo', user: @stubs.user, channel: @stubs.DM}
     @stubs._received.text.should.equal "#{@slackbot.robot.name} foo"
 
+  it 'Should return a message object with raw text and message', ->
+    messageData = {
+      subtype: 'message',
+      user: @stubs.user,
+      channel: @stubs.channel,
+      text: 'foo http://www.example.com bar',
+      rawText: 'foo <http://www.example.com> bar'
+    }
+    @slackbot.message messageData
+    should.equal (@stubs._received instanceof SlackTextMessage), true
+    should.equal @stubs._received.text, "foo http://www.example.com bar"
+    should.equal @stubs._received.rawText, "foo <http://www.example.com> bar"
+    should.equal @stubs._received.rawMessage, messageData
+
   it 'Should handle channel_join events as envisioned', ->
     @slackbot.message {subtype: 'channel_join', user: @stubs.user, channel: @stubs.channel}
     should.equal (@stubs._received instanceof EnterMessage), true
@@ -189,7 +204,7 @@ describe 'Handling incoming messages', ->
 
   it 'Should not crash with bot messages', ->
     @slackbot.message { subtype: 'bot_message', bot: @stubs.bot, channel: @stubs.channel, text: 'Pushing is the answer' }
-    should.equal (@stubs._received instanceof TextMessage), true
+    should.equal (@stubs._received instanceof SlackTextMessage), true
 
   it 'Should ignore messages it sent itself', ->
     @slackbot.message { subtype: 'bot_message', user: @stubs.self, channel: @stubs.channel, text: 'Ignore me' }


### PR DESCRIPTION
* [x] I've read and understood the [Contributing guidelines](./CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
* [x] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [x] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [x] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary
Prior to 900402ea254b0fdf5a819fd3073325c68f1692a9, hubot-slack returned a message object which included the raw text from the Slack API along with the raw Slack Message object. This was useful for middleware and scripts which reformatted Slack text in different ways than hubot-slack's own default formatter. This object was a subclass of hubot's `TextMessage` which was otherwise compatible.

For example, a middleware might try to detect URLs that were autoexpanded by the Slack API and restore them to their original format; this is only possible if the raw text is included so the unparsed URLs can be read.

#### Related Issues
#181 also discusses using this property (at the time when it still existed).

#### Test strategy
Added a test to the `SlackBot.message` code.