### PR TITLE
Initial fix

### DIFF
--- a/src/bot.coffee
+++ b/src/bot.coffee
@@ -37,7 +37,9 @@ class SlackBot extends Adapter
     @client = new SlackClient(@options, @robot)
 
   ###
-  Slackbot reload users timeout (reloads every 1 hour)
+  Slackbot loads full user list on the first brain load
+  QUESTION: why do brain adapters trigger a brain 'loaded' event each time a key
+  is set?
   ###
   setIsLoaded: (@isLoaded) ->
 

--- a/src/bot.coffee
+++ b/src/bot.coffee
@@ -35,6 +35,10 @@ class SlackBot extends Adapter
   constructor: (@robot, @options) ->
     @client = new SlackClient(@options, @robot)
 
+  ###
+  Slackbot reload users timeout (reloads every 1 hour)
+  ###
+  setLastTimeUsersUpdated: (@lastTimeUsersUpdated) ->
 
   ###
   Slackbot initialization
@@ -54,8 +58,12 @@ class SlackBot extends Adapter
     @client.on 'user_change', @userChange
 
     @client.web.users.list @loadUsers
+
     @robot.brain.on 'loaded', () =>
-      @client.web.users.list @loadUsers
+      if not @lastTimeUsersUpdated or (((new Date) - @lastTimeUsersUpdated) > (60 * 60 * 1000))
+        @client.web.users.list @loadUsers
+        this.setLastTimeUpdated(new Date)
+
 
     # Start logging in
     @client.connect()

--- a/src/bot.coffee
+++ b/src/bot.coffee
@@ -38,7 +38,7 @@ class SlackBot extends Adapter
   ###
   Slackbot reload users timeout (reloads every 1 hour)
   ###
-  setLastTimeUsersUpdated: (@lastTimeUsersUpdated) ->
+  setIsLoaded: (@isLoaded) ->
 
   ###
   Slackbot initialization
@@ -60,9 +60,9 @@ class SlackBot extends Adapter
     @client.web.users.list @loadUsers
 
     @robot.brain.on 'loaded', () =>
-      if not @lastTimeUsersUpdated or (((new Date) - @lastTimeUsersUpdated) > (60 * 60 * 1000))
+      if not @isLoaded
         @client.web.users.list @loadUsers
-        this.setLastTimeUpdated(new Date)
+        this.setIsLoaded(true)
 
 
     # Start logging in

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -31,6 +31,7 @@ class SlackClient
   Open connection to the Slack RTM API
   ###
   connect: ->
+    # QUESTION: why do we throw away the login data?
     @rtm.login()
 
 


### PR DESCRIPTION
* [x] I've read and understood the [Contributing guidelines](./CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
* [x] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [x] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [ ] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary
Currently the hubot slack adapter makes a call to users.list everytime we call robot.brain.set  since that fires the 'loaded' event. If a call updates several properties separately then you get multiple calls to the slack api to load users.

#### Related Issues
For #419

#### Test strategy
Currently this is manually tested and after a couple of hours of trying to figure out the test framework I had to cut my losses. If someone else can write a test for this or can help me write a test that would be appreciated. Used to using sinon where I can clearly see the calls made to functions. 