### PR TITLE
setup env vars for RtmClient and rtm.start options

### DIFF
--- a/docs/_pages/advanced_usage.md
+++ b/docs/_pages/advanced_usage.md
@@ -1,0 +1,38 @@
+---
+layout: page
+title: Advanced Usage
+permalink: /advanced_usage
+order: 5
+headings:
+    - title: Customizing rtm.start options
+    - title: Customizing the RTM Client
+---
+
+## Customizing rtm.start options
+
+Under the hood, each Hubot using this adapter is connected to Slack using the [RTM API](https://api.slack.com/rtm). A
+connection to the RTM API is initiated using the Web API method [`rtm.start`](https://api.slack.com/methods/rtm.start).
+By default, the adapter calls this method with only the required `token` parameter. If you have more specialized needs,
+such as opting into MPIM data, you can add additional parameters to that Web API call by setting an environment
+variable. The variable is called `HUBOT_SLACK_RTM_START_OPTS`, and its value should be a JSON-encoded string with
+the additional parameters as key-value pairs. Here is an example of running hubot with that environment variable set:
+
+```
+$ HUBOT_SLACK_TOKEN=xoxb-xxxxx HUBOT_SLACK_RTM_OPTIONS='{ "mpim_aware": true }' bin/hubot --adapter slack
+```
+
+## Customizing the RTM Client
+
+The RTM connection is handled by the `RtmClient` implementation from our handy
+[Slack SDK for Node](https://github.com/slackapi/node-slack-sdk). By default, the adapter instantiates the client with
+only the required `token` parameter, but many more are
+[available in the documentation](https://slackapi.github.io/node-slack-sdk/reference/RTMClient#new_RTMClient_new). You
+can customize the options for the `RtmClient` instance by setting an environment variable. The variable is called
+`HUBOT_SLACK_RTM_CLIENT_OPTS` and its value should be a JSON-encoded string with the additional parameters as key-value
+pairs. Note that not every option can only be set to JSON-encodable values; you won't be able to create an instance of
+`SlackDataStore` and pass it in via a JSON string but you can set the option to `false` to opt out of using a Data Store
+(not recommended). Here is an example of running hubot with a custom retry configuration:
+
+```
+$ HUBOT_SLACK_TOKEN=xoxb-xxxxx HUBOT_SLACK_RTM_CLIENT_OPTS='{ "retryConfig": { "retries": 20 } }' bin/hubot --adapter slack
+```

--- a/slack.coffee
+++ b/slack.coffee
@@ -1,4 +1,11 @@
 SlackBot = require './src/bot'
 
 exports.use = (robot) ->
-  new SlackBot robot, token: process.env.HUBOT_SLACK_TOKEN
+  options = token: process.env.HUBOT_SLACK_TOKEN
+  try
+    options.rtm = JSON.parse(process.env.HUBOT_SLACK_RTM_CLIENT_OPTS)
+  catch
+  try
+    options.rtmStart = JSON.parse(process.env.HUBOT_SLACK_RTM_START_OPTS)
+  catch
+  new SlackBot robot, options

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -1,23 +1,22 @@
-{RtmClient, WebClient, MemoryDataStore} = require '@slack/client'
+{RtmClient, WebClient} = require '@slack/client'
 SlackFormatter = require './formatter'
 _ = require 'lodash'
-
-SLACK_CLIENT_OPTIONS =
-  dataStore: new MemoryDataStore()
-
 
 class SlackClient
 
   constructor: (options, robot) ->
-    _.merge SLACK_CLIENT_OPTIONS, options
 
     @robot = robot
 
+    @robot.logger.debug "slack rtm client options: #{JSON.stringify(options.rtm)}"
+
     # RTM is the default communication client
-    @rtm = new RtmClient options.token, options
+    @rtm = new RtmClient options.token, options.rtm
+
+    @rtmStartOpts = options.rtmStart || {}
 
     # Web is the fallback for complex messages
-    @web = new WebClient options.token, options
+    @web = new WebClient options.token
 
     # Message formatter
     @format = new SlackFormatter(@rtm.dataStore)
@@ -31,8 +30,8 @@ class SlackClient
   Open connection to the Slack RTM API
   ###
   connect: ->
-    # QUESTION: why do we throw away the login data?
-    @rtm.login()
+    @robot.logger.debug "slack rtm start with options: #{JSON.stringify(@rtmStartOpts)}"
+    @rtm.start(@rtmStartOpts)
 
 
   ###

--- a/test/stubs.coffee
+++ b/test/stubs.coffee
@@ -118,6 +118,8 @@ beforeEach ->
   @stubs.rtm =
     login: =>
       @stubs._connected = true
+    start: =>
+      @stubs._connected = true
     on: (name, callback) =>
       console.log("#####")
       console.log(name)


### PR DESCRIPTION
fixes #421 

there aren't any tests here because it would require building a new test harness capable of launching a child process for hubot with predefined environment variables. that seems too expensive for now.

* [x] I've read and understood the [Contributing guidelines](./CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
* [x] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [x] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [ ] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).
