### PR TITLE
Add display_name to user object

### DIFF
--- a/src/bot.coffee
+++ b/src/bot.coffee
@@ -237,6 +237,7 @@ class SlackBot extends Adapter
     newUser =
       id: user.id
       name: user.name
+      display_name: user.profile.display_name
       real_name: user.real_name
       slack: {}
     newUser.email_address = user.profile.email if user.profile and user.profile.email

--- a/test/bot.coffee
+++ b/test/bot.coffee
@@ -306,16 +306,6 @@ describe 'Users data', ->
     should.equal user.email_address, @stubs.user.profile.email
     should.equal user.slack.misc, @stubs.user.misc
 
-  it 'Should add a user data (user with no profile)', ->
-    @slackbot.userChange(@stubs.usernoprofile)
-
-    user = @slackbot.robot.brain.data.users[@stubs.usernoprofile.id]
-    should.equal user.id, @stubs.usernoprofile.id
-    should.equal user.name, @stubs.usernoprofile.name
-    should.equal user.real_name, @stubs.usernoprofile.real_name
-    should.equal user.slack.misc, @stubs.usernoprofile.misc
-    (user).should.not.have.ownProperty('email_address')
-
   it 'Should add a user data (user with no email in profile)', ->
     @slackbot.userChange(@stubs.usernoemail)
 

--- a/test/stubs.coffee
+++ b/test/stubs.coffee
@@ -43,6 +43,7 @@ beforeEach ->
     real_name: 'real_name'
     id: 'U123'
     profile:
+      display_name: 'display_name'
       email: 'email@example.com'
     misc: 'misc'
   @stubs.bot =
@@ -52,22 +53,20 @@ beforeEach ->
     name: 'name.lname'
     id: 'U124'
     profile:
+      display_name: 'display_name.lname'
       email: 'name.lname@example.com'
   @stubs.userhyphen =
     name: 'name-lname'
     id: 'U125'
     profile:
+      display_name: 'display_name.name-lname'
       email: 'name-lname@example.com'
-  @stubs.usernoprofile =
-    name: 'name'
-    real_name: 'real_name'
-    id: 'U126'
-    misc: 'misc'
   @stubs.usernoemail =
     name: 'name'
     real_name: 'real_name'
     id: 'U126'
     profile:
+      display_name: 'display_name'
       foo: 'bar'
     misc: 'misc'
   @stubs.self =
@@ -75,16 +74,19 @@ beforeEach ->
     id: 'U456'
     bot_id: 'B456'
     profile:
+      display_name: 'display_name'
       email: 'self@example.com'
   @stubs.self_bot =
     name: 'self'
     id: 'B456'
     profile:
+      display_name: 'display_name'
       email: 'self@example.com'
   @stubs.org_user_not_in_workspace =
     name: 'name'
     id: 'W123'
     profile:
+      display_name: 'display_name'
       email: 'org_not_in_workspace@example.com'
   @stubs.team =
     name: 'Example Team'


### PR DESCRIPTION
###  Summary

Slack users now have a `profile` object which keeps track of the name they are displayed as in slack. This PR adds that field to the user object

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/hubot-slack/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).