### PR TITLE
Fix bug using robot's name for prepending

### DIFF
--- a/src/message.coffee
+++ b/src/message.coffee
@@ -79,7 +79,7 @@ class SlackTextMessage extends TextMessage
 
       if @_channel?.is_im
         startOfText = if text.indexOf('@') == 0 then 1 else 0
-        robotIsNamed = text.indexOf(@robot.name) == startOfText || text.indexOf(@robot.alias) == startOfText
+        robotIsNamed = text.indexOf(@_robot_name) == startOfText || text.indexOf(client.robot.alias) == startOfText
         # Assume it was addressed to us even if it wasn't
         if not robotIsNamed
           text = "#{@_robot_name} #{text}"     # If this is a DM, pretend it was addressed to us


### PR DESCRIPTION
###  Summary

Fixes an incorrectly merged community contribution that wasn't using the correct bot name.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/hubot-slack/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).