### PR TITLE
Return Hubot Users

### DIFF
--- a/src/bot.coffee
+++ b/src/bot.coffee
@@ -204,7 +204,7 @@ class SlackBot extends Adapter
           # prefer user over bot.
           # if both are set in the slack event, it represents an app or integration sending a message on behalf of a
           # user, so the user is the more appropriate value.
-          SlackTextMessage.makeSlackTextMessage(user, undefined, undefined, event, channel, @robot.name, @client, (message) =>
+          SlackTextMessage.makeSlackTextMessage(user, undefined, undefined, event, channel, @robot.name, @robot.alias, @client, (message) =>
             @receive message
           )
         # NOTE: channel_join should be replaced with a member_joined_channel event
@@ -221,7 +221,7 @@ class SlackBot extends Adapter
         when undefined
           @robot.logger.debug "Received message in channel: #{channel.name || channel.id}, from: #{user.name}"
           
-          SlackTextMessage.makeSlackTextMessage(user, undefined, undefined, event, channel, @robot.name, @client, (message) =>
+          SlackTextMessage.makeSlackTextMessage(user, undefined, undefined, event, channel, @robot.name, @robot.alias, @client, (message) =>
             @receive message
           )
         # NOTE: if we want to expose all remaining subtypes not covered above as a generic message implement an else

--- a/src/bot.coffee
+++ b/src/bot.coffee
@@ -62,7 +62,6 @@ class SlackBot extends Adapter
   # @public
   ###
   send: (envelope, messages...) ->
-    console.log("ENVELOPE #{JSON.stringify(envelope)}")
     for message in messages
       # NOTE: perhaps do envelope manipulation here instead of in the client (separation of concerns)
       @client.send(envelope, message) unless message is ''

--- a/src/bot.coffee
+++ b/src/bot.coffee
@@ -188,13 +188,14 @@ class SlackBot extends Adapter
     # slack.is_bot {Boolean}:   Flag indicating whether user is a bot
     # name {String}:            Slack username
     # real_name {String}:       Name of Slack user or bot
+    # room {String}:            Channel id of event (will be empty string if no channel)
     ###
     user = if user? then @robot.brain.userForId user.id, user else {}
 
     # Send to Hubot based on message type
     if event.type is 'message'
 
-      user.room = channel?.id
+      user.room = if channel? then channel.id else ''
 
       switch event.subtype
         when 'bot_message'
@@ -226,7 +227,7 @@ class SlackBot extends Adapter
     else if event.type is 'reaction_added' or event.type is 'reaction_removed'      
       # If the reaction is to a message, then the item.channel property will contain a conversation ID
       # Otherwise reactions can be on files and file comments, which are "global" and aren't contained in a conversation
-      user.room = event.item?.channel # when the item is not a message this will be undefined
+      user.room = if event.item? then event.item.channel else '' # when the item is not a message this will be undefined
       # Convert item user into a Hubot user
       item_user = if event.item_user? then @robot.brain.userForId event.item_user.id, event.item_user else {}
 

--- a/src/bot.coffee
+++ b/src/bot.coffee
@@ -6,7 +6,7 @@ class SlackBot extends Adapter
 
   ###*
   # Slackbot is an adapter for connecting Hubot to Slack
-  # @ tructor
+  # @constructor
   # @param {Robot} robot - the Hubot robot
   # @param {Object} options - configuration options for the adapter
   # @param {string} options.token - authentication token for Slack APIs
@@ -194,7 +194,7 @@ class SlackBot extends Adapter
     # Send to Hubot based on message type
     if event.type is 'message'
       # If bot user not found in users.info from client
-      return if !user?
+      user = if user? then user else {}
 
       user.room = channel?.id
 

--- a/src/bot.coffee
+++ b/src/bot.coffee
@@ -6,7 +6,7 @@ class SlackBot extends Adapter
 
   ###*
   # Slackbot is an adapter for connecting Hubot to Slack
-  # @constructor
+  # @ tructor
   # @param {Robot} robot - the Hubot robot
   # @param {Object} options - configuration options for the adapter
   # @param {string} options.token - authentication token for Slack APIs
@@ -177,20 +177,24 @@ class SlackBot extends Adapter
     # NOTE: coupled to getting `rtm.start` data
     return if user && (user?.id is @self.id)
 
+    
     ###*
-    # Hubot user object in Brain. User object returned guaranteed to contain:
+    # Hubot user object in Brain.
+    # User can represent a Slack user OR bot
+    # 
+    # The returned user from a message or reaction event is guaranteed to contain:
+    # 
     # id {String}:              Slack user ID
     # slack.is_bot {Boolean}:   Flag indicating whether user is a bot
     # name {String}:            Slack username
     # real_name {String}:       Name of Slack user or bot
     ###
-    # Check if user is just id for presence_change event
-    user = if user?.id? then @robot.brain.userForId user.id, user else user
+    user = if user?.id? then @robot.brain.userForId user.id, user else user # Checks if user is just id for presence_change
 
     # Send to Hubot based on message type
     if event.type is 'message'
       # If bot user not found in users.info from client
-      return if !user
+      return if !user?
 
       user.room = channel?.id
 
@@ -198,9 +202,6 @@ class SlackBot extends Adapter
         when 'bot_message'
           @robot.logger.debug "Received message in channel: #{channel.name || channel.id}, from: #{user.name}"
 
-          # prefer user over bot.
-          # if both are set in the slack event, it represents an app or integration sending a message on behalf of a
-          # user, so the user is the more appropriate value.
           SlackTextMessage.makeSlackTextMessage(user, undefined, undefined, event, channel, @robot.name, @robot.alias, @client, (message) =>
             @receive message
           )

--- a/src/bot.coffee
+++ b/src/bot.coffee
@@ -188,7 +188,7 @@ class SlackBot extends Adapter
     # slack.is_bot {Boolean}:   Flag indicating whether user is a bot
     # name {String}:            Slack username
     # real_name {String}:       Name of Slack user or bot
-    # room {String}:            Channel id of event (will be empty string if no channel)
+    # room {String}:            Slack channel ID for event (will be empty string if no channel in event)
     ###
     user = if user? then @robot.brain.userForId user.id, user else {}
 

--- a/src/bot.coffee
+++ b/src/bot.coffee
@@ -62,6 +62,7 @@ class SlackBot extends Adapter
   # @public
   ###
   send: (envelope, messages...) ->
+    console.log("ENVELOPE #{JSON.stringify(envelope)}")
     for message in messages
       # NOTE: perhaps do envelope manipulation here instead of in the client (separation of concerns)
       @client.send(envelope, message) unless message is ''
@@ -180,12 +181,21 @@ class SlackBot extends Adapter
     # Send to Hubot based on message type
     if event.type is 'message'
       
-      # NOTE: use robot.brain.userForId(id, options) to initialize the user object
-      # think about whether this is true for bots and if we want to be storing bots in the same brain namespace as users
       # Hubot expects this format for TextMessage Listener
-
+      # Flag added to user object
+      is_bot = !user? && bot?
       user = user || bot || {}
-      user.room = channel?.id
+      user.is_bot = if user.is_bot then user.is_bot else is_bot
+
+      ###*
+      # Hubot user object in Brain. User object returned guaranteed to contain:
+      # id {String}:        Slack user ID
+      # is_bot {Boolean}:   Flag indicating whether user is a bot
+      # name {String}:      Slack username
+      # real_name {String}: First and Last name of Slack user
+      ###
+      user = @updateUserInBrain(user)
+      #user.room = channel?.id
 
       switch event.subtype
         when 'bot_message'

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -217,7 +217,7 @@ class SlackClient
           # bot_id exists on all messages with subtype bot_message
           # these messages only have a user property if sent from a bot user (xoxb token). therefore
           # the above assignment will not happen for all messages from custom integrations or apps without a bot user
-          Promise.promisify(@findBotUser, { context: @ })(event.bot_id).then((res) =>
+          return Promise.promisify(@findBotUser, { context: @ })(event.bot_id).then((res) =>
             event.user = res
             return event
           )

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -162,6 +162,14 @@ class SlackClient
     return true
 
   ###*
+  # Function to determine if given botId in partialResult
+  ###
+  botContinueFn: (botId, partialResult) ->
+    for member in partialResult
+      if member.profile?.bot_id == botId then return false
+    return true
+
+  ###*
   # Invokes callback with Slack user object for a given botId 
   ###
   findBotUser: (botId, callback) ->
@@ -169,11 +177,7 @@ class SlackClient
       if err then return callback(err)
       for member in res.members
         if member.profile?.bot_id == botId then return callback(null, member)
-    , (partialResult) =>
-        for member in partialResult
-          if member.profile?.bot_id == botId then return false
-        return true
-    )
+    , (partialResult) => return @botContinueFn(botId, partialResult))
 
   ###*
   # Event handler for Slack RTM events

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -195,7 +195,7 @@ class SlackClient
           # bot_id exists on all messages with subtype bot_message
           # these messages only have a user property if sent from a bot user (xoxb token). therefore
           # the above assignment will not happen for all messages from custom integrations or apps without a bot user
-          loadUsers(event.bot_id, (err, res) =>
+          @loadUsers(event.bot_id, (err, res) =>
             event.user = res
             try @eventHandler(event)
             catch error then @robot.logger.error "An error occurred while processing an RTM event: #{error.message}."

--- a/src/message.coffee
+++ b/src/message.coffee
@@ -44,10 +44,11 @@ class SlackTextMessage extends TextMessage
   # text       - The parsed message text
   # rawText    - The unparsed message text
   # rawMessage - The Slack Message object
-  constructor: (@user, text, rawText, @rawMessage, channel, robot_name) ->
+  constructor: (@user, text, rawText, @rawMessage, channel, robot_name, robot_alias) ->
     # private instance properties (not trying to expand API contract)
     @_channel = channel
     @_robot_name = robot_name
+    @_robot_alias = robot_alias
 
     # public instance property initialization
     @rawText = if rawText? then rawText else @rawMessage.text
@@ -79,7 +80,7 @@ class SlackTextMessage extends TextMessage
 
       if @_channel?.is_im
         startOfText = if text.indexOf('@') == 0 then 1 else 0
-        robotIsNamed = text.indexOf(@_robot_name) == startOfText || text.indexOf(client.robot.alias) == startOfText
+        robotIsNamed = text.indexOf(@_robot_name) == startOfText || text.indexOf(@_robot_alias) == startOfText
         # Assume it was addressed to us even if it wasn't
         if not robotIsNamed
           text = "#{@_robot_name} #{text}"     # If this is a DM, pretend it was addressed to us
@@ -179,8 +180,8 @@ class SlackTextMessage extends TextMessage
   ###*
   # Factory method to construct SlackTextMessage
   ###
-  @makeSlackTextMessage: (@user, text, rawText, @rawMessage, channel, robot_name, client, cb) ->
-    message = new SlackTextMessage(@user, text, rawText, @rawMessage, channel, robot_name, client)
+  @makeSlackTextMessage: (@user, text, rawText, @rawMessage, channel, robot_name, robot_alias, client, cb) ->
+    message = new SlackTextMessage(@user, text, rawText, @rawMessage, channel, robot_name, robot_alias, client)
 
     if not message.text? then message.buildText(client, () ->
       setImmediate(() -> cb(message))

--- a/test/bot.coffee
+++ b/test/bot.coffee
@@ -251,6 +251,16 @@ describe 'Handling incoming messages', ->
     @slackbot.eventHandler {type: 'message', subtype: 'bot_message', user: @stubs.user, channel: @stubs.channel, text: 'Pushing is the answer', returnRawText: true }
     return
   
+  it 'Should handle single user presence_change events as envisioned', ->
+    @slackbot.robot.brain.userForId(@stubs.user.id, @stubs.user)
+    presenceMessage = {
+      type: 'presence_change', user: @stubs.user.id, presence: 'away'
+    }
+    @slackbot.eventHandler presenceMessage
+    should.equal (@stubs._received instanceof PresenceMessage), true
+    should.equal @stubs._received.users[0].id, @stubs.user.id
+    @stubs._received.users.length.should.equal 1
+
   it 'Should handle presence_change events as envisioned', ->
     @slackbot.robot.brain.userForId(@stubs.user.id, @stubs.user)
     presenceMessage = {
@@ -261,12 +271,7 @@ describe 'Handling incoming messages', ->
     should.equal @stubs._received.users[0].id, @stubs.user.id
     @stubs._received.users.length.should.equal 1
 
-  #TODO: review these tests to add testing for more complex functionality
   it 'Should ignore messages it sent itself', ->
-    @slackbot.eventHandler {type: 'message', subtype: 'bot_message', user: @stubs.self, channel: @stubs.channel, text: 'Ignore me' }
-    should.equal @stubs._received, undefined
-
-  it 'Should ignore messages it sent itself, if sent as a botuser', ->
     @slackbot.eventHandler {type: 'message', subtype: 'bot_message', user: @stubs.self, channel: @stubs.channel, text: 'Ignore me' }
     should.equal @stubs._received, undefined
 
@@ -275,9 +280,8 @@ describe 'Handling incoming messages', ->
     @slackbot.eventHandler reactionMessage
     should.equal @stubs._received, undefined
 
-  it 'Should ignore reaction events that it generated itself as a botuser', ->
-    reactionMessage = { type: 'reaction_added', user: @stubs.self, reaction: 'thumbsup', event_ts: '1360782804.083113' }
-    @slackbot.eventHandler reactionMessage
+  it 'Should handle undefined users as envisioned', ->
+    @slackbot.eventHandler {type: 'message', subtype: 'bot_message', user: undefined, channel: @stubs.channel}
     should.equal @stubs._received, undefined
 
   it 'Should handle reaction events from users who are in different workspace in shared channel', ->

--- a/test/bot.coffee
+++ b/test/bot.coffee
@@ -280,9 +280,12 @@ describe 'Handling incoming messages', ->
     @slackbot.eventHandler reactionMessage
     should.equal @stubs._received, undefined
 
-  it 'Should handle undefined users as envisioned', ->
-    @slackbot.eventHandler {type: 'message', subtype: 'bot_message', user: undefined, channel: @stubs.channel}
-    should.equal @stubs._received, undefined
+  it 'Should handle undefined users as envisioned', (done)->
+    @stubs.receiveMock.onReceived = (msg) ->
+      should.equal (msg instanceof SlackTextMessage), true
+      done()
+    @slackbot.eventHandler {type: 'message', subtype: 'bot_message', user: undefined, channel: @stubs.channel, text: 'Foo'}
+    return
 
   it 'Should handle reaction events from users who are in different workspace in shared channel', ->
     reactionMessage = {

--- a/test/bot.coffee
+++ b/test/bot.coffee
@@ -248,7 +248,7 @@ describe 'Handling incoming messages', ->
     @stubs.receiveMock.onReceived = (msg) ->
       should.equal (msg instanceof SlackTextMessage), true
       done()
-    @slackbot.eventHandler {type: 'message', subtype: 'bot_message', bot: @stubs.bot, channel: @stubs.channel, text: 'Pushing is the answer', returnRawText: true }
+    @slackbot.eventHandler {type: 'message', subtype: 'bot_message', user: @stubs.user, channel: @stubs.channel, text: 'Pushing is the answer', returnRawText: true }
     return
   
   it 'Should handle presence_change events as envisioned', ->
@@ -261,12 +261,13 @@ describe 'Handling incoming messages', ->
     should.equal @stubs._received.users[0].id, @stubs.user.id
     @stubs._received.users.length.should.equal 1
 
+  #TODO: review these tests to add testing for more complex functionality
   it 'Should ignore messages it sent itself', ->
     @slackbot.eventHandler {type: 'message', subtype: 'bot_message', user: @stubs.self, channel: @stubs.channel, text: 'Ignore me' }
     should.equal @stubs._received, undefined
 
   it 'Should ignore messages it sent itself, if sent as a botuser', ->
-    @slackbot.eventHandler {type: 'message', subtype: 'bot_message', bot: @stubs.self_bot, channel: @stubs.channel, text: 'Ignore me' }
+    @slackbot.eventHandler {type: 'message', subtype: 'bot_message', user: @stubs.self, channel: @stubs.channel, text: 'Ignore me' }
     should.equal @stubs._received, undefined
 
   it 'Should ignore reaction events that it generated itself', ->
@@ -275,7 +276,7 @@ describe 'Handling incoming messages', ->
     should.equal @stubs._received, undefined
 
   it 'Should ignore reaction events that it generated itself as a botuser', ->
-    reactionMessage = { type: 'reaction_added', user: @stubs.self_bot, reaction: 'thumbsup', event_ts: '1360782804.083113' }
+    reactionMessage = { type: 'reaction_added', user: @stubs.self, reaction: 'thumbsup', event_ts: '1360782804.083113' }
     @slackbot.eventHandler reactionMessage
     should.equal @stubs._received, undefined
 

--- a/test/bot.coffee
+++ b/test/bot.coffee
@@ -46,33 +46,33 @@ describe 'Logger', ->
 describe 'Send Messages', ->
 
   it 'Should send a message', ->
-    sentMessages = @slackbot.send {room: 'general'}, 'message'
+    sentMessages = @slackbot.send {room: @stubs.channel.id}, 'message'
     sentMessages.length.should.equal 1
     sentMessages[0].should.equal 'message'
 
   it 'Should send multiple messages', ->
-    sentMessages = @slackbot.send {room: 'general'}, 'one', 'two', 'three'
+    sentMessages = @slackbot.send {room: @stubs.channel.id}, 'one', 'two', 'three'
     sentMessages.length.should.equal 3
 
   it 'Should not send empty messages', ->
-    sentMessages = @slackbot.send {room: 'general'}, 'Hello', '', '', 'world!'
+    sentMessages = @slackbot.send {room: @stubs.channel.id}, 'Hello', '', '', 'world!'
     # Removes undefined (or unsent) messages from sentMessages
     _.remove(sentMessages, _.isUndefined)
     sentMessages.length.should.equal 2
 
   it 'Should not fail for inexistant user', ->
-    chai.expect(() => @slackbot.send {room: 'inexistant'}, 'Hello').to.not.throw()
+    chai.expect(() => @slackbot.send {room: 'U987'}, 'Hello').to.not.throw()
 
   it 'Should open a DM channel if needed', ->
     msg = 'Test'
-    @slackbot.send {room: 'name'}, msg
-    @stubs._msg.should.eql msg
+    @slackbot.send {room: @stubs.user.id}, msg
+    @stubs._dmmsg.should.eql msg
 
   it 'Should use an existing DM channel if possible', ->
     msg = 'Test'
-    @slackbot.send {room: '@user2'}, msg
+    @slackbot.send {room: @stubs.user.id}, msg
     @stubs._dmmsg.should.eql msg
-    @stubs._room.should.eql '@user2'
+    @stubs._room.should.eql @stubs.user.id
 
   it 'Should send a message to a user', ->
     @slackbot.send @stubs.user, 'message'
@@ -82,11 +82,11 @@ describe 'Send Messages', ->
 
 describe 'Client sending message', ->
   it 'Should append as_user = true', ->
-    @client.send {room: 'name'}, {text: 'foo', user: @stubs.user, channel: @stubs.channel}
+    @client.send {room: @stubs.user.id}, {text: 'foo', user: @stubs.user, channel: @stubs.channel}
     @stubs._opts.as_user.should.eql true
 
   it 'Should append as_user = true only as a default', ->
-    @client.send {room: 'name'}, {text: 'foo', user: @stubs.user, channel: @stubs.channel, as_user: false}
+    @client.send {room: @stubs.user.id}, {text: 'foo', user: @stubs.user, channel: @stubs.channel, as_user: false}
     @stubs._opts.as_user.should.eql false
 
 describe 'Reply to Messages', ->

--- a/test/bot.coffee
+++ b/test/bot.coffee
@@ -68,12 +68,6 @@ describe 'Send Messages', ->
     @slackbot.send {room: @stubs.user.id}, msg
     @stubs._dmmsg.should.eql msg
 
-  it 'Should use an existing DM channel if possible', ->
-    msg = 'Test'
-    @slackbot.send {room: @stubs.user.id}, msg
-    @stubs._dmmsg.should.eql msg
-    @stubs._room.should.eql @stubs.user.id
-
   it 'Should send a message to a user', ->
     @slackbot.send @stubs.user, 'message'
     @stubs._dmmsg.should.eql 'message'
@@ -82,11 +76,11 @@ describe 'Send Messages', ->
 
 describe 'Client sending message', ->
   it 'Should append as_user = true', ->
-    @client.send {room: @stubs.user.id}, {text: 'foo', user: @stubs.user, channel: @stubs.channel}
+    @client.send {room: @stubs.channel.id}, {text: 'foo', user: @stubs.user, channel: @stubs.channel}
     @stubs._opts.as_user.should.eql true
 
   it 'Should append as_user = true only as a default', ->
-    @client.send {room: @stubs.user.id}, {text: 'foo', user: @stubs.user, channel: @stubs.channel, as_user: false}
+    @client.send {room: @stubs.channel.id}, {text: 'foo', user: @stubs.user, channel: @stubs.channel, as_user: false}
     @stubs._opts.as_user.should.eql false
 
 describe 'Reply to Messages', ->
@@ -254,7 +248,7 @@ describe 'Handling incoming messages', ->
   it 'Should handle single user presence_change events as envisioned', ->
     @slackbot.robot.brain.userForId(@stubs.user.id, @stubs.user)
     presenceMessage = {
-      type: 'presence_change', user: @stubs.user.id, presence: 'away'
+      type: 'presence_change', user: @stubs.user, presence: 'away'
     }
     @slackbot.eventHandler presenceMessage
     should.equal (@stubs._received instanceof PresenceMessage), true

--- a/test/client.coffee
+++ b/test/client.coffee
@@ -123,10 +123,13 @@ describe 'send()', ->
 
 describe 'loadUsers()', ->
   it 'should make successive calls to users.list', ->
-    @client.loadUsers (err, result) =>
+    @client.loadUsers null, (err, result) =>
       @stubs?._listCount.should.equal 2
-      result.members.length.should.equal 3
+      result.members.length.should.equal 4
   it 'should handle errors', ->
     @stubs._listError = true
-    @client.loadUsers (err, result) =>
+    @client.loadUsers null, (err, result) =>
       err.should.be.an.Error
+  it 'should retrieve bot user', ->
+    @client.loadUsers 'B1', (err, result) =>
+      result.id.should.equal 4

--- a/test/client.coffee
+++ b/test/client.coffee
@@ -133,3 +133,6 @@ describe 'loadUsers()', ->
   it 'should retrieve bot user', ->
     @client.loadUsers 'B1', (err, result) =>
       result.id.should.equal 4
+  it 'should handle users when retrieving bot user', ->
+    @client.loadUsers 'NOBOT', (err, result) =>
+      should.equal result, undefined

--- a/test/client.coffee
+++ b/test/client.coffee
@@ -42,6 +42,23 @@ describe 'onEvent()', ->
     setTimeout(( =>
       @stubs.robot.logger.logs.should.not.have.property('error')
     ), 0);
+  it 'should successfully convert bot users', (done) ->
+    @client.onEvent (message) =>
+      message.should.be.ok
+      message.user.id.should.equal 4
+      message.channel.name.should.equal @stubs.channel.name
+      done()
+    # the shape of the following object is a raw RTM message event: https://api.slack.com/events/message
+    @client.rtm.emit('message', {
+      type: 'message',
+      bot_id: 'B1'
+      channel: @stubs.channel.id,
+      text: 'blah'    
+    })
+    # NOTE: the following check does not appear to work as expected
+    setTimeout(( =>
+      @stubs.robot.logger.logs.should.not.have.property('error')
+    ), 0);
   it 'should log an error when expanded info cannot be fetched using the Web API', (done) ->
     # NOTE: to be certain nothing goes wrong in the rejection handling, the "unhandledRejection" / "rejectionHandled"
     # global events need to be instrumented

--- a/test/client.coffee
+++ b/test/client.coffee
@@ -140,16 +140,18 @@ describe 'send()', ->
 
 describe 'loadUsers()', ->
   it 'should make successive calls to users.list', ->
-    @client.loadUsers null, (err, result) =>
+    @client.loadUsers (err, result) =>
       @stubs?._listCount.should.equal 2
       result.members.length.should.equal 4
   it 'should handle errors', ->
     @stubs._listError = true
-    @client.loadUsers null, (err, result) =>
+    @client.loadUsers (err, result) =>
       err.should.be.an.Error
+
+describe 'findBotUser()', ->  
   it 'should retrieve bot user', ->
-    @client.loadUsers 'B1', (err, result) =>
+    @client.findBotUser 'B1', (err, result) =>
       result.id.should.equal 4
-  it 'should handle users when retrieving bot user', ->
-    @client.loadUsers 'NOBOT', (err, result) =>
-      should.equal result, undefined
+  it 'should handle unfound bot user', ->
+    @client.findBotUser 'oops', (err, result) =>
+      err.should.be.an.Error

--- a/test/stubs.coffee
+++ b/test/stubs.coffee
@@ -178,7 +178,7 @@ beforeEach ->
       else
         return Promise.reject(new Error('usersMock could not match user ID'))
   @stubs.userListPageWithNextCursor = {
-    members: [{ id: 1 }, { id: 2 }]
+    members: [{ id: 1 }, { id: 2 }, { id: 4, profile: { bot_id: 'B1' } }]
     response_metadata: {
       next_cursor: 'mock_cursor'
     }


### PR DESCRIPTION
###  Summary

Do some work to standardize the structure of a user inside of the adapter. Modify `loadUsers()` to fetch a Slack user from a bot id. Addresses #414 and #427.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/hubot-slack/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).