### PR TITLE
Fix Slack API Calls

### DIFF
--- a/src/bot.coffee
+++ b/src/bot.coffee
@@ -177,7 +177,6 @@ class SlackBot extends Adapter
     # NOTE: coupled to getting `rtm.start` data
     return if user && (user?.id is @self.id)
 
-    
     ###*
     # Hubot user object in Brain.
     # User can represent a Slack human user or bot user
@@ -248,7 +247,7 @@ class SlackBot extends Adapter
   # @private
   ###
   usersLoaded: (err, res) =>
-    if err || !res.ok
+    if err || !res.members.length
       @robot.logger.error "Can't fetch users"
       return
     @updateUserInBrain member for member in res.members

--- a/src/message.coffee
+++ b/src/message.coffee
@@ -148,8 +148,9 @@ class SlackTextMessage extends TextMessage
   # Returns name of user with id
   ###
   replaceUser: (client, id, mentions) ->
-    client.web.users.info(id).then((user) ->
-      if user
+    client.web.users.info(id).then((res) =>
+      if res?.user?
+        user = res.user
         mention = new SlackMention(user.id, 'user', user)
         mentions.push(mention)
         return "@#{user.name}"
@@ -164,8 +165,9 @@ class SlackTextMessage extends TextMessage
   # Returns name of channel with id
   ###
   replaceConversation: (client, id, mentions) ->
-    client.web.conversations.info(id).then((conversation) ->
-      if conversation
+    client.web.conversations.info(id).then((res) =>
+      if res?.channel?
+        conversation = res.channel
         mention = new SlackMention(conversation.id, 'conversation', conversation)
         mentions.push(mention)
         return "\##{conversation.name}"

--- a/test/client.coffee
+++ b/test/client.coffee
@@ -27,8 +27,8 @@ describe 'onEvent()', ->
   it 'should emit pre-processed messages to the callback', (done) ->
     @client.onEvent (message) =>
       message.should.be.ok
-      #message.user.real_name.should.equal @stubs.user.real_name
-      #message.channel.name.should.equal @stubs.channel.name
+      message.user.real_name.should.equal @stubs.user.real_name
+      message.channel.name.should.equal @stubs.channel.name
       done()
     # the shape of the following object is a raw RTM message event: https://api.slack.com/events/message
     @client.rtm.emit('message', {

--- a/test/client.coffee
+++ b/test/client.coffee
@@ -27,8 +27,8 @@ describe 'onEvent()', ->
   it 'should emit pre-processed messages to the callback', (done) ->
     @client.onEvent (message) =>
       message.should.be.ok
-      message.user.real_name.should.equal @stubs.user.real_name
-      message.channel.name.should.equal @stubs.channel.name
+      #message.user.real_name.should.equal @stubs.user.real_name
+      #message.channel.name.should.equal @stubs.channel.name
       done()
     # the shape of the following object is a raw RTM message event: https://api.slack.com/events/message
     @client.rtm.emit('message', {

--- a/test/stubs.coffee
+++ b/test/stubs.coffee
@@ -157,19 +157,22 @@ beforeEach ->
       if @stubs.receiveMock.onTopic? then @stubs.receiveMock.onTopic @stubs._topic
     info: (conversationId) =>
       if conversationId == @stubs.channel.id
-        return Promise.resolve(@stubs.channel)
+        return Promise.resolve({ok: true, channel: @stubs.channel})
       else if conversationId == @stubs.DM.id
-        return Promise.resolve(@stubs.DM)
+        return Promise.resolve({ok: true, channel: @stubs.DM})
       else if conversationId == 'C789'
         return Promise.resolve()
       else
         return Promise.reject(new Error('conversationsMock could not match conversation ID'))
   @stubs.botsMock =
-    info: (botId) =>
+    info: (event) =>
+      botId = event.bot
       if botId == @stubs.bot.id
-        return Promise.resolve(@stubs.bot)
-      if botId == @stubs.undefined_user_bot.id
-        return Promise.resolve(@stubs.undefined_user_bot)
+        return Promise.resolve({ok: true, bot: @stubs.bot})
+      else if botId == @stubs.undefined_user_bot.id
+        return Promise.resolve({ok: true, bot: @stubs.undefined_user_bot})
+      else
+        return Promise.reject(new Error('botsMock could not match bot ID'))
   @stubs.usersMock =
     list: (opts, cb) =>
       @stubs._listCount = if @stubs?._listCount then @stubs._listCount + 1 else 1
@@ -180,9 +183,9 @@ beforeEach ->
         cb(null, @stubs.userListPageWithNextCursor)
     info: (userId) =>
       if userId == @stubs.user.id
-        return Promise.resolve(@stubs.user)
+        return Promise.resolve({ok: true, user: @stubs.user})
       else if userId == @stubs.org_user_not_in_workspace.id
-        return Promise.resolve(@stubs.org_user_not_in_workspace)
+        return Promise.resolve({ok: true, user: @stubs.org_user_not_in_workspace})
       else if userId == 'U789'
         return Promise.resolve()
       else


### PR DESCRIPTION
###  Summary

#465 introduced new calls to the Web API that were being incorrectly called and used, as noted in #468. This fixes the usage of the calls.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/hubot-slack/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).