### PR TITLE
WIP: optimize calls to conversations.info

### DIFF
--- a/src/bot.coffee
+++ b/src/bot.coffee
@@ -208,8 +208,7 @@ class SlackBot extends Adapter
   # @param {Object} event
   # @param {string} event.type - this specifies the event type
   # @param {SlackUserInfo} [event.user] - the description of the user creating this event as returned by `users.info`
-  # @param {SlackConversationInfo} [event.channel] - the description of the conversation where the event happened as
-  # returned by `conversations.info`
+  # @param {string} [event.channel] - the conversation ID for where this event took place
   # @param {SlackBotInfo} [event.bot] - the description of the bot creating this event as returned by `bots.info`
   ###
   eventHandler: (event) =>
@@ -238,32 +237,34 @@ class SlackBot extends Adapter
 
       # Hubot expects all user objects to have a room property that is used in the envelope for the message after it
       # is received
-      user.room = if channel? then channel.id else ""
+      user.room = if channel? then channel else ""
 
       switch event.subtype
         when "bot_message"
-          @robot.logger.debug "Received text message in channel: #{channel.id}, from: #{user.id} (bot)"
-          SlackTextMessage.makeSlackTextMessage(user, undefined, undefined, event, channel, @robot.name, @robot.alias, @client, (message) =>
+          @robot.logger.debug "Received text message in channel: #{channel}, from: #{user.id} (bot)"
+          SlackTextMessage.makeSlackTextMessage(user, undefined, undefined, event, channel, @robot.name, @robot.alias, @client, (error, message) =>
+            return @robot.logger.error "Dropping message due to error #{error.message}" if error
             @receive message
           )
 
         # NOTE: channel_join should be replaced with a member_joined_channel event
         when "channel_join", "group_join"
-          @robot.logger.debug "Received enter message for user: #{user.id}, joining: #{channel.id}"
+          @robot.logger.debug "Received enter message for user: #{user.id}, joining: #{channel}"
           @receive new EnterMessage user
 
         # NOTE: channel_leave should be replaced with a member_left_channel event
         when "channel_leave", "group_leave"
-          @robot.logger.debug "Received leave message for user: #{user.id}, leaving: #{channel.id}"
+          @robot.logger.debug "Received leave message for user: #{user.id}, leaving: #{channel}"
           @receive new LeaveMessage user
 
         when "channel_topic", "group_topic"
-          @robot.logger.debug "Received topic change message in conversation: #{channel.id}, new topic: #{event.topic}, set by: #{user.id}"
+          @robot.logger.debug "Received topic change message in conversation: #{channel}, new topic: #{event.topic}, set by: #{user.id}"
           @receive new TopicMessage user, event.topic, event.ts
 
         when undefined
-          @robot.logger.debug "Received text message in channel: #{channel.id}, from: #{user.id} (human)"
-          SlackTextMessage.makeSlackTextMessage(user, undefined, undefined, event, channel, @robot.name, @robot.alias, @client, (message) =>
+          @robot.logger.debug "Received text message in channel: #{channel}, from: #{user.id} (human)"
+          SlackTextMessage.makeSlackTextMessage(user, undefined, undefined, event, channel, @robot.name, @robot.alias, @client, (error, message) =>
+            return @robot.logger.error "Dropping message due to error #{error.message}" if error
             @receive message
           )
 

--- a/src/message.coffee
+++ b/src/message.coffee
@@ -61,13 +61,13 @@ class SlackTextMessage extends TextMessage
   # @param {string} rawMessage.ts
   # @param {string} [rawMessage.thread_ts] - the identifier for the thread the message is a part of
   # @param {string} [rawMessage.attachments] - Slack message attachments
-  # @param {SlackConversationInfo} channel - The conversation where this message was sent.
+  # @param {string} channel_id - The conversation where this message was sent.
   # @param {string} robot_name - The Slack username for this robot
   # @param {string} robot_alias - The alias for this robot
   ###
-  constructor: (@user, @text, rawText, @rawMessage, channel, robot_name, robot_alias) ->
+  constructor: (@user, @text, rawText, @rawMessage, channel_id, robot_name, robot_alias) ->
     # private instance properties
-    @_channel = channel
+    @_channel_id = channel_id
     @_robot_name = robot_name
     @_robot_alias = robot_alias
 
@@ -95,16 +95,20 @@ class SlackTextMessage extends TextMessage
       text = text + "\n" + attachment_text
 
     # Replace links in text async to fetch user and channel info (if present)
-    @replaceLinks(client, text)
-      .then (replacedText) =>
+    mentionFormatting = @replaceLinks(client, text)
+    # TODO: make this go through a conversations cache
+    fetchingConversationInfo = client.web.conversations.info(@_channel_id)
+    Promise.all([mentionFormatting, fetchingConversationInfo])
+      .then (results) =>
+        [ replacedText, conversationInfo ] = results
         text = replacedText
-        text = text.replace /&lt;/g, '<'
-        text = text.replace /&gt;/g, '>'
-        text = text.replace /&amp;/g, '&'
+        text = text.replace /&lt;/g, "<"
+        text = text.replace /&gt;/g, ">"
+        text = text.replace /&amp;/g, "&"
 
         # special handling for message text when inside a DM conversation
-        if @_channel?.is_im
-          startOfText = if text.indexOf('@') == 0 then 1 else 0
+        if conversationInfo.channel.is_im
+          startOfText = if text.indexOf("@") == 0 then 1 else 0
           robotIsNamed = text.indexOf(@_robot_name) == startOfText || text.indexOf(@_robot_alias) == startOfText
           # Assume it was addressed to us even if it wasn't
           if not robotIsNamed
@@ -112,6 +116,9 @@ class SlackTextMessage extends TextMessage
 
         @text = text
         cb()
+      .catch (error) =>
+        client.robot.logger.error "An error occurred while building text: #{error.message}"
+        cb(error)
 
   ###*
   # Replace links inside of text
@@ -204,7 +211,7 @@ class SlackTextMessage extends TextMessage
       .then (res) =>
         if res?.channel?
           conversation = res.channel
-          mentions.push(new SlackMention(conversation.id, 'conversation', conversation))
+          mentions.push(new SlackMention(conversation.id, "conversation", conversation))
           return "\##{conversation.name}"
         else return "<\##{id}>"
       .catch (error) =>
@@ -224,19 +231,23 @@ class SlackTextMessage extends TextMessage
   # @param {string} rawMessage.ts
   # @param {string} [rawMessage.thread_ts] - the identifier for the thread the message is a part of
   # @param {string} [rawMessage.attachments] - Slack message attachments
-  # @param {SlackConversationInfo} channel - The conversation where this message was sent.
+  # @param {string} channel_id - The conversation where this message was sent.
   # @param {string} robot_name - The Slack username for this robot
   # @param {string} robot_alias - The alias for this robot
   # @param {SlackClient} client - client used to fetch more data
   # @param {function} cb - callback to return the result
   ###
-  @makeSlackTextMessage: (@user, text, rawText, @rawMessage, channel, robot_name, robot_alias, client, cb) ->
-    message = new SlackTextMessage(@user, text, rawText, @rawMessage, channel, robot_name, robot_alias, client)
+  @makeSlackTextMessage: (@user, text, rawText, @rawMessage, channel_id, robot_name, robot_alias, client, cb) ->
+    message = new SlackTextMessage(@user, text, rawText, @rawMessage, channel_id, robot_name, robot_alias, client)
 
-    if not message.text? then message.buildText client, () ->
-      setImmediate(() -> cb(message))
+    # creates a completion function that consistently calls the callback after this function has returned
+    done = (message) -> setImmediate(() -> cb(null, message))
+
+    if not message.text? then message.buildText client, (error) ->
+      return cb(error) if error
+      done(message)
     else
-      setImmediate(() -> cb(message))
+      done(message)
 
 exports.SlackTextMessage = SlackTextMessage
 exports.ReactionMessage = ReactionMessage


### PR DESCRIPTION
###  Summary

currently, `SlackClient` will fetch the conversation info for every incoming event, whether that object is used or not. this is wasteful because besides the conversation ID, the only time the info is used to inside `SlackTextMessage#buildText()` and that is to check the `is_im` property. this PR moves that fetch into `SlackTextMessage#buildText()` when its determined to be needed.

one idea to further optimize would be to cache the conversation info in memory (not in the Brain) for a specific and configurable TTL so that this fetch isn't executed as often.

no tests yet, this is to serve as an experiment for the team to discuss.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/hubot-slack/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).