### PR TITLE
renames Robot.react to Robot.hearReaction

### DIFF
--- a/src/client.coffee
+++ b/src/client.coffee
@@ -64,7 +64,7 @@ class SlackClient
     @eventHandler = callback if @eventHandler != callback
 
   ###*
-  # Attach event handlers to the RTM stream
+  # DEPRECATED Attach event handlers to the RTM stream
   # @public
   # @deprecated This method is being removed without a replacement in the next major version.
   ###

--- a/src/extensions.coffee
+++ b/src/extensions.coffee
@@ -10,10 +10,10 @@
 # @param {Object} [options] - an object of additional parameters keyed on extension name.
 # @param {Function} callback - a function that is called with a Response object if the matcher function returns true
 ###
-Robot::react = (matcher, options, callback) ->
+Robot::hearReaction = (matcher, options, callback) ->
   matchReaction = (msg) -> msg instanceof ReactionMessage
 
-  if arguments.length == 1
+  if not options and not callback
     return @listen matchReaction, matcher
 
   else if matcher instanceof Function
@@ -24,6 +24,23 @@ Robot::react = (matcher, options, callback) ->
     options = matcher
 
   @listen matchReaction, options, callback
+
+###*
+# DEPRECATED Adds a listener for ReactionMessages with the provided matcher, options, and callback.
+#
+# This method is deprecated in favor of Robot#hearReaction(), which is exactly the same, except with a clearer name.
+#
+# @deprecated
+# @public
+# @param {Function} [matcher] - a function to determine if the listener should run. must return something
+# truthy if it should and that value with be available on `response.match`.
+# @param {Object} [options] - an object of additional parameters keyed on extension name.
+# @param {Function} callback - a function that is called with a Response object if the matcher function returns true
+###
+Robot::react = (matcher, options, callback) ->
+  @logger.warning "Robot#react() is a deprecated method and will be removed in the next major version of " +
+    "hubot-slack. It is recommended to use Robot#hearReaction() which behaves exactly the same, but has a clearer name."
+  @hearReaction(matcher, options, callback)
 
 ###*
 # Adds a Listener for PresenceMessages with the provided matcher, options, and callback

--- a/test/stubs.coffee
+++ b/test/stubs.coffee
@@ -240,6 +240,7 @@ beforeEach ->
     robot.listeners = []
     robot.listen = Robot.prototype.listen.bind(robot)
     robot.react = Robot.prototype.react.bind(robot)
+    robot.hearReaction = Robot.prototype.hearReaction.bind(robot)
     robot.presenceChange = Robot.prototype.presenceChange.bind(robot)
     robot
   @stubs.callback = do ->


### PR DESCRIPTION
###  Summary 

and preserves former as an alias, fixes #455

Describe the goal of this PR. Mention any related Issue numbers.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/hubot-slack/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).