### PR TITLE
Upgrade @slack/client to 4.2.0 to address CVE-2018-3728

### DIFF
--- a/docs/_pages/advanced_usage.md
+++ b/docs/_pages/advanced_usage.md
@@ -25,9 +25,9 @@ $ HUBOT_SLACK_TOKEN=xoxb-xxxxx HUBOT_SLACK_RTM_START_OPTS='{ "mpim_aware": true 
 
 ## Customizing the RTM Client
 
-The RTM connection is handled by the `RtmClient` class from our handy
+The RTM connection is handled by the `RTMClient` class from our handy
 **Slack Developer Kit for Node.js version 3**. By default, the adapter instantiates the client with the required
-`token` parameter, but more options are available. You can customize the options for the `RtmClient` instance by setting
+`token` parameter, but more options are available. You can customize the options for the `RTMClient` instance by setting
 an environment variable. The variable is called `HUBOT_SLACK_RTM_CLIENT_OPTS`, and its value should be a JSON-encoded
 string with the additional parameters as key-value pairs. Note that not every option can only be set to JSON-encodable
 values; you won't be able to create an instance of `SlackDataStore` and pass it in via a JSON string but you can set the

--- a/docs/_posts/2017-08-24-v4.4.0.md
+++ b/docs/_posts/2017-08-24-v4.4.0.md
@@ -3,5 +3,5 @@ layout: changelog
 ---
   * Restore ability to inspect `rawText` and `rawMessage` on SlackMessage objects (#413) - thanks @mistydemeo
   * Relieve extraneous `users.list` Web API method calls from occurring due to hubot brain (#419) - thanks @chapmanc
-  * Add ability to set RtmClient options and `rtm.start` options via env vars (#431, #421) - thanks @aoberoi
+  * Add ability to set RTMClient options and `rtm.start` options via env vars (#431, #421) - thanks @aoberoi
   * Documentation fix (#426) - thanks @TonioOoOo

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "url": "https://github.com/slackapi/hubot-slack/issues"
   },
   "dependencies": {
-    "@slack/client": "^3.4.0",
+    "@slack/client": "^4.2.0",
     "bluebird": "^3.5.1",
     "lodash": "^3.10.1"
   },

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -1,6 +1,6 @@
 _                      = require "lodash"
 Promise                = require "bluebird"
-{RtmClient, WebClient} = require "@slack/client"
+{RTMClient, WebClient} = require "@slack/client"
 SlackFormatter         = require "./formatter"
 
 class SlackClient
@@ -14,8 +14,8 @@ class SlackClient
   # @constructor
   # @param {Object} options - Configuration options for this SlackClient instance
   # @param {string} options.token - Slack API token for authentication
-  # @param {Object} [options.rtm={}] - Configuration options for owned RtmClient instance
-  # @param {Object} [options.rtmStart={}] - Configuration options for RtmClient#start() method
+  # @param {Object} [options.rtm={}] - Configuration options for owned RTMClient instance
+  # @param {Object} [options.rtmStart={}] - Configuration options for RTMClient#start() method
   # @param {boolean} [options.noRawText=false] - Deprecated: All SlackTextMessages (subtype of TextMessage) will contain
   # both the formatted text property and the rawText property
   # @param {Robot} robot - Hubot robot instance
@@ -26,10 +26,10 @@ class SlackClient
     # NOTE: the recommended initialization options are `{ dataStore: false, useRtmConnect: true }`. However the
     # @rtm.dataStore property is publically accessible, so the recommended settings cannot be used without breaking
     # this object's API. The property is no longer used internally.
-    @rtm = new RtmClient options.token, options.rtm
+    @rtm = new RTMClient options.token, options.rtm
     @web = new WebClient options.token
 
-    @robot.logger.debug "RtmClient initialized with options: #{JSON.stringify(options.rtm)}"
+    @robot.logger.debug "RTMClient initialized with options: #{JSON.stringify(options.rtm)}"
     @rtmStartOpts = options.rtmStart || {}
 
     # Message formatter
@@ -51,7 +51,7 @@ class SlackClient
   # @public
   ###
   connect: ->
-    @robot.logger.debug "RtmClient#start() with options: #{JSON.stringify(@rtmStartOpts)}"
+    @robot.logger.debug "RTMClient#start() with options: #{JSON.stringify(@rtmStartOpts)}"
     @rtm.start(@rtmStartOpts)
 
   ###*

--- a/test/client.coffee
+++ b/test/client.coffee
@@ -1,16 +1,15 @@
-{RtmClient, WebClient, MemoryDataStore} = require '@slack/client'
+{RTMClient, WebClient, MemoryDataStore} = require '@slack/client'
 SlackFormatter = require '../src/formatter'
 should = require 'should'
 _ = require 'lodash'
 
 describe 'Init', ->
   it 'Should initialize with an RTM client', ->
-    (@client.rtm instanceof RtmClient).should.equal true
-    @client.rtm._token.should.equal 'xoxb-faketoken'
+    (@client.rtm instanceof RTMClient).should.equal true
 
   it 'Should initialize with a Web client', ->
     (@client.web instanceof WebClient).should.equal true
-    @client.web._token.should.equal 'xoxb-faketoken'
+    @client.web.token.should.equal 'xoxb-faketoken'
 
   it 'Should initialize with a SlackFormatter - DEPRECATED', ->
     (@client.format instanceof SlackFormatter).should.equal true
@@ -106,7 +105,8 @@ describe 'disconnect()', ->
   it 'should remove all RTM listeners - LEGACY', ->
     @client.on 'some_event', _.noop
     @client.disconnect()
-    @client.rtm.listeners('some_event', true).should.not.be.ok
+    debugger
+    @client.rtm.listeners('some_event', true).should.be.empty
 
 describe 'setTopic()', ->
 


### PR DESCRIPTION
###  Summary

CVE-2018-3728 applies to versions of hoek pre 4.2.1, which hubot-slack currently includes. This PR attempts to rectify that.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/hubot-slack/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).


The 3.x branch of `@slack/client` has been abandoned and contains a locked reference to an older version of request which contains a vulnerable version of hoek. The only way forward is to move to the 4.x branch of `@slack/client` unless things change over there.

The migration guide can be found here:
https://github.com/slackapi/node-slack-sdk/wiki/Migration-Guide-for-v4

In order to get the suite to pass I had to s/RtmClient/RTMClient/g across this repo. I also had to modify 3 tests to mimic API changes upstream, but once done all tests pass and no source code modifications other than the capitalization of RTMClient were necessary.

This could use lots of eyes. Despite codecov showing 82% I am not familiar enough with this code to say what unexpected breakages may await.