### PR TITLE
Fix typo in presence example

### DIFF
--- a/docs/_pages/basic_usage.md
+++ b/docs/_pages/basic_usage.md
@@ -218,7 +218,7 @@ module.exports = (robot) ->
 
   robot.presenceChange (res) ->
 
-    # res.message is a PresenceMessssage instance that represents the presence change Hubot just heard
+    # res.message is a PresenceMessage instance that represents the presence change Hubot just heard
     names = (user.name for user in res.message.users).join ", "
 
     message = if res.message.presence is "away" then "Bye bye #{names}" else "Glad you are back #{names}"


### PR DESCRIPTION
###  Summary

This is just a simple typo fix in one of the comments of the examples.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/hubot-slack/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).