### PR TITLE
Decrease Web API Dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "hubot": "^2.19.0",
     "istanbul": "^0.4.3",
     "mocha": "^3.5.3",
-    "should": "^2.0.2"
+    "should": "^8.0.0"
   },
   "engines": {
     "node": ">= 0.12",

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -263,7 +263,7 @@ class SlackClient
               event.user = fetched.bot
 
             # bot_id exists on all messages with subtype bot_message
-            # these messages only have a user property if sent from a bot user (xoxb token). therefore
+            # these messages only have a user_id property if sent from a bot user (xoxb token). therefore
             # the above assignment will not happen for all messages from custom integrations or apps without a bot user
             else if fetched.bot.user_id?
               return @web.users.info(fetched.bot.user_id).then((res) =>

--- a/test/client.coffee
+++ b/test/client.coffee
@@ -183,3 +183,23 @@ describe 'loadUsers()', ->
     @stubs._listError = true
     @client.loadUsers (err, result) =>
       err.should.be.an.Error
+
+describe 'fetchBotUser()', ->
+  it 'should return user representation from map', ->
+    @client.botUserIdMap[@stubs.bot.id] = @stubs.user
+    result = @client.fetchBotUser @stubs.bot.id
+    result.id.should.equal @stubs.user.id
+
+  it 'should return promise if no user representation exists in map', ->
+    result = @client.fetchBotUser @stubs.bot.id
+    result.should.be.Promise()
+
+describe 'fetchUser()', ->
+  it 'should return user representation from brain', ->
+    @slackbot.updateUserInBrain(@stubs.user)
+    user = @client.fetchUser @stubs.user.id
+    user.id.should.equal @stubs.user.id
+
+  it 'should return promise if no user exists in brain', ->
+    result = @client.fetchUser @stubs.user.id
+    result.should.be.Promise()

--- a/test/client.coffee
+++ b/test/client.coffee
@@ -75,6 +75,41 @@ describe 'onEvent()', ->
     setTimeout(( =>
       @stubs.robot.logger.logs.should.not.have.property('error')
     ), 0);
+  it 'should update bot id to user representation map', (done) ->
+    @client.onEvent (message) =>
+      message.should.be.ok
+      @client.botUserIdMap[@stubs.bot.id].id.should.equal @stubs.user.id
+      done()
+    
+    # the shape of the following object is a raw RTM message event: https://api.slack.com/events/message
+    @client.rtm.emit('message', {
+      type: 'message',
+      bot_id: @stubs.bot.id,
+      channel: @stubs.channel.id,
+      text: 'blah'
+    })
+
+    setTimeout(( =>
+      @stubs.robot.logger.logs.should.not.have.property('error')
+    ), 0);
+  it 'should use user representation for bot id in map', (done) ->
+    @client.onEvent (message) =>
+      message.should.be.ok
+      message.user.id.should.equal @stubs.user.id
+      done()
+    
+    @client.botUserIdMap[@stubs.bot.id] = @stubs.user
+    # the shape of the following object is a raw RTM message event: https://api.slack.com/events/message
+    @client.rtm.emit('message', {
+      type: 'message',
+      bot_id: @stubs.bot.id,
+      channel: @stubs.channel.id,
+      text: 'blah'
+    })
+
+    setTimeout(( =>
+      @stubs.robot.logger.logs.should.not.have.property('error')
+    ), 0);
   it 'should log an error when expanded info cannot be fetched using the Web API', (done) ->
     # NOTE: to be certain nothing goes wrong in the rejection handling, the "unhandledRejection" / "rejectionHandled"
     # global events need to be instrumented
@@ -91,7 +126,7 @@ describe 'onEvent()', ->
       @stubs.robot.logger.logs?.error.length.should.equal 1
       done()
     ), 0);
-
+  
 describe 'on() - DEPRECATED', ->
   it 'Should register events on the RTM stream', ->
     event = undefined

--- a/test/stubs.coffee
+++ b/test/stubs.coffee
@@ -174,6 +174,8 @@ beforeEach ->
   @stubs.botsMock =
     info: (event) =>
       botId = event.bot
+      console.log(botId)
+      console.log(@stubs.bot.id)
       if botId == @stubs.bot.id
         return Promise.resolve({ok: true, bot: @stubs.bot})
       else if botId == @stubs.undefined_user_bot.id

--- a/test/stubs.coffee
+++ b/test/stubs.coffee
@@ -174,8 +174,6 @@ beforeEach ->
   @stubs.botsMock =
     info: (event) =>
       botId = event.bot
-      console.log(botId)
-      console.log(@stubs.bot.id)
       if botId == @stubs.bot.id
         return Promise.resolve({ok: true, bot: @stubs.bot})
       else if botId == @stubs.undefined_user_bot.id


### PR DESCRIPTION
###  Summary

Add a local mapping for bot user ID to user representation to reduce dependency on `bots.info` and `users.info` calls.

Fetch event `user` and `item_user` from the brain if possible - if not, use `users.info`

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/hubot-slack/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).