### PR TITLE
Update conversations.info calls to Web API

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,10 @@
     {
       "email": "aoberoi@gmail.com",
       "name": "Ankur Oberoi"
+    },
+    {
+      "email": "sdewael@slack-corp.com",
+      "name": "Shane DeWael"
     }
   ]
 }

--- a/src/bot.coffee
+++ b/src/bot.coffee
@@ -38,7 +38,6 @@ class SlackBot extends Adapter
     @client.rtm.on "close", @close
     @client.rtm.on "error", @error
     @client.rtm.on "authenticated", @authenticated
-    @client.rtm.on "user_change", @updateUserInBrain
     @client.onEvent @eventHandler
 
     # Synchronize workspace users to brain
@@ -229,7 +228,7 @@ class SlackBot extends Adapter
     # real_name {String}:       Name of Slack user or bot
     # room {String}:            Slack channel ID for event (will be empty string if no channel in event)
     ###
-    user = if user? then @updateUserInBrain user else {}
+    user = if user? then @client.updateUserInBrain user else {}
 
     # Send to Hubot based on message type
     if event.type is "message"
@@ -307,48 +306,6 @@ class SlackBot extends Adapter
     if err || !res.members.length
       @robot.logger.error "Can't fetch users"
       return
-    @updateUserInBrain member for member in res.members
-
-  ###*
-  # Update user record in the Hubot Brain. This may be called as a handler for `user_change` events or to update a
-  # a single user with its latest SlackUserInfo object.
-  #
-  # @private
-  # @param {SlackUserInfo|SlackUserChangeEvent} event_or_user - an object containing information about a Slack user
-  # that should be updated in the brain
-  ###
-  updateUserInBrain: (event_or_user) =>
-    # NOTE: why is this line here and why would this method be called without any parameter?
-    return unless event_or_user
-
-    # if this method was invoked as a `user_change` event handler, unwrap the user from the event
-    user = if event_or_user.type == 'user_change' then event_or_user.user else event_or_user
-
-    # create a full representation of the user in the shape we persist for Hubot brain based on the parameter
-    # all top-level properties of the user are meant to be shared across adapters
-    newUser =
-      id: user.id
-      name: user.name
-      real_name: user.real_name
-      slack: {}
-    # don't create keys for properties that have no value, because the empty value will become authoritative
-    newUser.email_address = user.profile.email if user.profile?.email?
-    # all "non-standard" keys of a user are namespaced inside the slack property, so they don't interfere with other
-    # adapters (in case this hubot switched between adapters)
-    for key, value of user
-      newUser.slack[key] = value
-
-    # merge any existing representation of this user already stored in the brain into the new representation
-    if user.id of @robot.brain.data.users
-      for key, value of @robot.brain.data.users[user.id]
-        # the merge strategy is to only copy over data for keys that do not exist in the new representation
-        # this means the entire `slack` property is treated as one value
-        unless key of newUser
-          newUser[key] = value
-
-    # remove the existing representation and write the new representation to the brain
-    delete @robot.brain.data.users[user.id]
-    @robot.brain.userForId user.id, newUser
-
+    @client.updateUserInBrain member for member in res.members
 
 module.exports = SlackBot

--- a/src/bot.coffee
+++ b/src/bot.coffee
@@ -208,8 +208,7 @@ class SlackBot extends Adapter
   # @param {Object} event
   # @param {string} event.type - this specifies the event type
   # @param {SlackUserInfo} [event.user] - the description of the user creating this event as returned by `users.info`
-  # @param {SlackConversationInfo} [event.channel] - the description of the conversation where the event happened as
-  # returned by `conversations.info`
+  # @param {string} [event.channel] - the conversation ID for where this event took place
   # @param {SlackBotInfo} [event.bot] - the description of the bot creating this event as returned by `bots.info`
   ###
   eventHandler: (event) =>
@@ -238,32 +237,34 @@ class SlackBot extends Adapter
 
       # Hubot expects all user objects to have a room property that is used in the envelope for the message after it
       # is received
-      user.room = if channel? then channel.id else ""
+      user.room = if channel? then channel else ""
 
       switch event.subtype
         when "bot_message"
-          @robot.logger.debug "Received text message in channel: #{channel.id}, from: #{user.id} (bot)"
-          SlackTextMessage.makeSlackTextMessage(user, undefined, undefined, event, channel, @robot.name, @robot.alias, @client, (message) =>
+          @robot.logger.debug "Received text message in channel: #{channel}, from: #{user.id} (bot)"
+          SlackTextMessage.makeSlackTextMessage(user, undefined, undefined, event, channel, @robot.name, @robot.alias, @client, (error, message) =>
+            return @robot.logger.error "Dropping message due to error #{error.message}" if error
             @receive message
           )
 
         # NOTE: channel_join should be replaced with a member_joined_channel event
         when "channel_join", "group_join"
-          @robot.logger.debug "Received enter message for user: #{user.id}, joining: #{channel.id}"
+          @robot.logger.debug "Received enter message for user: #{user.id}, joining: #{channel}"
           @receive new EnterMessage user
 
         # NOTE: channel_leave should be replaced with a member_left_channel event
         when "channel_leave", "group_leave"
-          @robot.logger.debug "Received leave message for user: #{user.id}, leaving: #{channel.id}"
+          @robot.logger.debug "Received leave message for user: #{user.id}, leaving: #{channel}"
           @receive new LeaveMessage user
 
         when "channel_topic", "group_topic"
-          @robot.logger.debug "Received topic change message in conversation: #{channel.id}, new topic: #{event.topic}, set by: #{user.id}"
+          @robot.logger.debug "Received topic change message in conversation: #{channel}, new topic: #{event.topic}, set by: #{user.id}"
           @receive new TopicMessage user, event.topic, event.ts
 
         when undefined
-          @robot.logger.debug "Received text message in channel: #{channel.id}, from: #{user.id} (human)"
-          SlackTextMessage.makeSlackTextMessage(user, undefined, undefined, event, channel, @robot.name, @robot.alias, @client, (message) =>
+          @robot.logger.debug "Received text message in channel: #{channel}, from: #{user.id} (human)"
+          SlackTextMessage.makeSlackTextMessage(user, undefined, undefined, event, channel, @robot.name, @robot.alias, @client, (error, message) =>
+            return @robot.logger.error "Dropping message due to error #{error.message}" if error
             @receive message
           )
 

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -3,8 +3,6 @@ Promise                = require "bluebird"
 {RtmClient, WebClient} = require "@slack/client"
 SlackFormatter         = require "./formatter"
 
-# TODO: make this client brain-aware
-
 class SlackClient
   ###*
   # Number used for limit when making paginated requests to Slack Web API list methods
@@ -39,9 +37,12 @@ class SlackClient
     # be removed without breaking this object's API. The property is no longer used internally.
     @format = new SlackFormatter(@rtm.dataStore, @robot)
 
-    # Map to convert bot user IDs (BXXXXXXXX) to user IDs (UXXXXXXXX/WXXXXXXXX) for events from custom 
+    # Map to convert bot user IDs (BXXXXXXXX) to user representations for events from custom 
     # integrations and apps without a bot user
     @botUserIdMap = {}
+
+    # Map to convert conversation IDs to conversation representations
+    @channelData = {}
 
     # Event handling
     # NOTE: add channel join and leave events

--- a/src/message.coffee
+++ b/src/message.coffee
@@ -96,8 +96,8 @@ class SlackTextMessage extends TextMessage
 
     # Replace links in text async to fetch user and channel info (if present)
     mentionFormatting = @replaceLinks(client, text)
-    # TODO: make this go through a conversations cache
-    fetchingConversationInfo = client.web.conversations.info(@_channel_id)
+    # Fetch conversation info
+    fetchingConversationInfo = @fetchConversation(client, @_channel_id)
     Promise.all([mentionFormatting, fetchingConversationInfo])
       .then (results) =>
         [ replacedText, conversationInfo ] = results
@@ -105,6 +105,13 @@ class SlackTextMessage extends TextMessage
         text = text.replace /&lt;/g, "<"
         text = text.replace /&gt;/g, ">"
         text = text.replace /&amp;/g, "&"
+
+        # Add conversation info to conversation map
+        if not client.channelData[@_channel_id]? and conversationInfo.channel?
+          client.channelData[@_channel_id] = {
+            conversation: conversationInfo.channel,
+            updated: Date.now()
+          }
 
         # special handling for message text when inside a DM conversation
         if conversationInfo.channel.is_im
@@ -175,6 +182,22 @@ class SlackTextMessage extends TextMessage
     return Promise.all(parts)
       .then (substrings) ->
         return substrings.join("")
+
+  ###*
+  # Fetch conversation information from conversation map
+  # @private
+  ###
+  fetchConversation: (client, conversationId) ->
+    # Current date minus 5 minutes (time of expiration for conversation info)
+    expiration = Date.now() - (60000*5)
+
+    # Check whether conversation is held in client's channelData map and whether information is expired
+    return client.channelData[conversationId].conversation if client.channelData[conversationId]?.conversation? and expiration < client.channelData[conversationId]?.updated
+
+    # Delete data from map if it's expired
+    delete client.channelData[conversationId] if client.channelData[conversationId]?
+    # Return conversations.info promise
+    client.web.conversations.info(conversationId)
 
   ###*
   # Creates a mention from a user ID

--- a/src/message.coffee
+++ b/src/message.coffee
@@ -61,13 +61,13 @@ class SlackTextMessage extends TextMessage
   # @param {string} rawMessage.ts
   # @param {string} [rawMessage.thread_ts] - the identifier for the thread the message is a part of
   # @param {string} [rawMessage.attachments] - Slack message attachments
-  # @param {SlackConversationInfo} channel - The conversation where this message was sent.
+  # @param {string} channel_id - The conversation where this message was sent.
   # @param {string} robot_name - The Slack username for this robot
   # @param {string} robot_alias - The alias for this robot
   ###
-  constructor: (@user, @text, rawText, @rawMessage, channel, robot_name, robot_alias) ->
+  constructor: (@user, @text, rawText, @rawMessage, channel_id, robot_name, robot_alias) ->
     # private instance properties
-    @_channel = channel
+    @_channel_id = channel_id
     @_robot_name = robot_name
     @_robot_alias = robot_alias
 
@@ -95,16 +95,20 @@ class SlackTextMessage extends TextMessage
       text = text + "\n" + attachment_text
 
     # Replace links in text async to fetch user and channel info (if present)
-    @replaceLinks(client, text)
-      .then (replacedText) =>
+    mentionFormatting = @replaceLinks(client, text)
+    # TODO: make this go through a conversations cache
+    fetchingConversationInfo = client.web.conversations.info(@_channel_id)
+    Promise.all([mentionFormatting, fetchingConversationInfo])
+      .then (results) =>
+        [ replacedText, conversationInfo ] = results
         text = replacedText
-        text = text.replace /&lt;/g, '<'
-        text = text.replace /&gt;/g, '>'
-        text = text.replace /&amp;/g, '&'
+        text = text.replace /&lt;/g, "<"
+        text = text.replace /&gt;/g, ">"
+        text = text.replace /&amp;/g, "&"
 
         # special handling for message text when inside a DM conversation
-        if @_channel?.is_im
-          startOfText = if text.indexOf('@') == 0 then 1 else 0
+        if conversationInfo.channel.is_im
+          startOfText = if text.indexOf("@") == 0 then 1 else 0
           robotIsNamed = text.indexOf(@_robot_name) == startOfText || text.indexOf(@_robot_alias) == startOfText
           # Assume it was addressed to us even if it wasn't
           if not robotIsNamed
@@ -112,6 +116,9 @@ class SlackTextMessage extends TextMessage
 
         @text = text
         cb()
+      .catch (error) =>
+        client.robot.logger.error "An error occurred while building text: #{error.message}"
+        cb(error)
 
   ###*
   # Replace links inside of text
@@ -204,7 +211,7 @@ class SlackTextMessage extends TextMessage
       .then (res) =>
         if res?.channel?
           conversation = res.channel
-          mentions.push(new SlackMention(conversation.id, 'conversation', conversation))
+          mentions.push(new SlackMention(conversation.id, "conversation", conversation))
           return "\##{conversation.name}"
         else return "<\##{id}>"
       .catch (error) =>
@@ -224,19 +231,23 @@ class SlackTextMessage extends TextMessage
   # @param {string} rawMessage.ts
   # @param {string} [rawMessage.thread_ts] - the identifier for the thread the message is a part of
   # @param {string} [rawMessage.attachments] - Slack message attachments
-  # @param {SlackConversationInfo} channel - The conversation where this message was sent.
+  # @param {string} channel_id - The conversation where this message was sent.
   # @param {string} robot_name - The Slack username for this robot
   # @param {string} robot_alias - The alias for this robot
   # @param {SlackClient} client - client used to fetch more data
   # @param {function} cb - callback to return the result
   ###
-  @makeSlackTextMessage: (@user, text, rawText, @rawMessage, channel, robot_name, robot_alias, client, cb) ->
-    message = new SlackTextMessage(@user, text, rawText, @rawMessage, channel, robot_name, robot_alias, client)
+  @makeSlackTextMessage: (@user, text, rawText, @rawMessage, channel_id, robot_name, robot_alias, client, cb) ->
+    message = new SlackTextMessage(@user, text, rawText, @rawMessage, channel_id, robot_name, robot_alias, client)
 
-    if not message.text? then message.buildText client, () ->
-      setImmediate(() -> cb(message))
+    # creates a completion function that consistently calls the callback after this function has returned
+    done = (message) -> setImmediate(() -> cb(null, message))
+
+    if not message.text? then message.buildText client, (error) ->
+      return cb(error) if error
+      done(message)
     else
-      setImmediate(() -> cb(message))
+      done(message)
 
 exports.SlackTextMessage = SlackTextMessage
 exports.ReactionMessage = ReactionMessage

--- a/src/message.coffee
+++ b/src/message.coffee
@@ -108,13 +108,15 @@ class SlackTextMessage extends TextMessage
 
         # Add conversation info to conversation map
         if not client.channelData[@_channel_id]? and conversationInfo.channel?
+          # Use only the channel object
+          conversationInfo = conversationInfo.channel
+          # Add channel to map
           client.channelData[@_channel_id] = {
-            conversation: conversationInfo.channel,
+            conversation: conversationInfo,
             updated: Date.now()
           }
-
         # special handling for message text when inside a DM conversation
-        if conversationInfo.channel.is_im
+        if conversationInfo.is_im
           startOfText = if text.indexOf("@") == 0 then 1 else 0
           robotIsNamed = text.indexOf(@_robot_name) == startOfText || text.indexOf(@_robot_alias) == startOfText
           # Assume it was addressed to us even if it wasn't
@@ -189,10 +191,11 @@ class SlackTextMessage extends TextMessage
   ###
   fetchConversation: (client, conversationId) ->
     # Current date minus 5 minutes (time of expiration for conversation info)
-    expiration = Date.now() - (60000*5)
+    expiration = Date.now() - (5 * 60 * 1000)
 
     # Check whether conversation is held in client's channelData map and whether information is expired
-    return client.channelData[conversationId].conversation if client.channelData[conversationId]?.conversation? and expiration < client.channelData[conversationId]?.updated
+    return client.channelData[conversationId].conversation if client.channelData[conversationId]?.conversation? and 
+      expiration < client.channelData[conversationId]?.updated
 
     # Delete data from map if it's expired
     delete client.channelData[conversationId] if client.channelData[conversationId]?

--- a/test/bot.coffee
+++ b/test/bot.coffee
@@ -74,11 +74,11 @@ describe 'Send Messages', ->
 
 describe 'Client sending message', ->
   it 'Should append as_user = true', ->
-    @client.send {room: @stubs.channel.id}, {text: 'foo', user: @stubs.user, channel: @stubs.channel}
+    @client.send {room: @stubs.channel.id}, {text: 'foo', user: @stubs.user, channel: @stubs.channel.id}
     @stubs._opts.as_user.should.eql true
 
   it 'Should append as_user = true only as a default', ->
-    @client.send {room: @stubs.channel.id}, {text: 'foo', user: @stubs.user, channel: @stubs.channel, as_user: false}
+    @client.send {room: @stubs.channel.id}, {text: 'foo', user: @stubs.user, channel: @stubs.channel.id, as_user: false}
     @stubs._opts.as_user.should.eql false
 
 describe 'Reply to Messages', ->
@@ -173,32 +173,32 @@ describe 'Handling incoming messages', ->
     return
 
   it 'Should handle channel_join events as envisioned', ->
-    @slackbot.eventHandler {type: 'message', subtype: 'channel_join', user: @stubs.user, channel: @stubs.channel}
+    @slackbot.eventHandler {type: 'message', subtype: 'channel_join', user: @stubs.user, channel: @stubs.channel.id}
     should.equal (@stubs._received instanceof EnterMessage), true
     @stubs._received.user.id.should.equal @stubs.user.id
 
   it 'Should handle channel_leave events as envisioned', ->
-    @slackbot.eventHandler {type: 'message', subtype: 'channel_leave', user: @stubs.user, channel: @stubs.channel}
+    @slackbot.eventHandler {type: 'message', subtype: 'channel_leave', user: @stubs.user, channel: @stubs.channel.id}
     should.equal (@stubs._received instanceof LeaveMessage), true
     @stubs._received.user.id.should.equal @stubs.user.id
 
   it 'Should handle channel_topic events as envisioned', ->
-    @slackbot.eventHandler {type: 'message', subtype: 'channel_topic', user: @stubs.user, channel: @stubs.channel}
+    @slackbot.eventHandler {type: 'message', subtype: 'channel_topic', user: @stubs.user, channel: @stubs.channel.id}
     should.equal (@stubs._received instanceof TopicMessage), true
     @stubs._received.user.id.should.equal @stubs.user.id
 
   it 'Should handle group_join events as envisioned', ->
-    @slackbot.eventHandler {type: 'message', subtype: 'group_join', user: @stubs.user, channel: @stubs.channel}
+    @slackbot.eventHandler {type: 'message', subtype: 'group_join', user: @stubs.user, channel: @stubs.channel.id}
     should.equal (@stubs._received instanceof EnterMessage), true
     @stubs._received.user.id.should.equal @stubs.user.id
 
   it 'Should handle group_leave events as envisioned', ->
-    @slackbot.eventHandler {type: 'message', subtype: 'group_leave', user: @stubs.user, channel: @stubs.channel}
+    @slackbot.eventHandler {type: 'message', subtype: 'group_leave', user: @stubs.user, channel: @stubs.channel.id}
     should.equal (@stubs._received instanceof LeaveMessage), true
     @stubs._received.user.id.should.equal @stubs.user.id
 
   it 'Should handle group_topic events as envisioned', ->
-    @slackbot.eventHandler {type: 'message', subtype: 'group_topic', user: @stubs.user, channel: @stubs.channel}
+    @slackbot.eventHandler {type: 'message', subtype: 'group_topic', user: @stubs.user, channel: @stubs.channel.id}
     should.equal (@stubs._received instanceof TopicMessage), true
     @stubs._received.user.id.should.equal @stubs.user.id
 
@@ -260,7 +260,7 @@ describe 'Handling incoming messages', ->
     @stubs._received.users.length.should.equal 1
 
   it 'Should ignore messages it sent itself', ->
-    @slackbot.eventHandler {type: 'message', subtype: 'bot_message', user: @stubs.self, channel: @stubs.channel, text: 'Ignore me' }
+    @slackbot.eventHandler {type: 'message', subtype: 'bot_message', user: @stubs.self, channel: @stubs.channel.id, text: 'Ignore me' }
     should.equal @stubs._received, undefined
 
   it 'Should ignore reaction events that it generated itself', ->
@@ -386,72 +386,6 @@ describe 'Robot.hearReaction', ->
     listener.matcher(@reactionMessage).should.be.false
 
 describe 'Users data', ->
-  it 'Should add a user data', ->
-    @slackbot.updateUserInBrain(@stubs.user)
-
-    user = @slackbot.robot.brain.data.users[@stubs.user.id]
-    should.equal user.id, @stubs.user.id
-    should.equal user.name, @stubs.user.name
-    should.equal user.real_name, @stubs.user.real_name
-    should.equal user.email_address, @stubs.user.profile.email
-    should.equal user.slack.misc, @stubs.user.misc
-
-  it 'Should add a user data (user with no profile)', ->
-    @slackbot.updateUserInBrain(@stubs.usernoprofile)
-
-    user = @slackbot.robot.brain.data.users[@stubs.usernoprofile.id]
-    should.equal user.id, @stubs.usernoprofile.id
-    should.equal user.name, @stubs.usernoprofile.name
-    should.equal user.real_name, @stubs.usernoprofile.real_name
-    should.equal user.slack.misc, @stubs.usernoprofile.misc
-    (user).should.not.have.ownProperty('email_address')
-
-  it 'Should add a user data (user with no email in profile)', ->
-    @slackbot.updateUserInBrain(@stubs.usernoemail)
-
-    user = @slackbot.robot.brain.data.users[@stubs.usernoemail.id]
-    should.equal user.id, @stubs.usernoemail.id
-    should.equal user.name, @stubs.usernoemail.name
-    should.equal user.real_name, @stubs.usernoemail.real_name
-    should.equal user.slack.misc, @stubs.usernoemail.misc
-    (user).should.not.have.ownProperty('email_address')
-
-  it 'Should modify a user data', ->
-    @slackbot.updateUserInBrain(@stubs.user)
-
-    user = @slackbot.robot.brain.data.users[@stubs.user.id]
-    should.equal user.id, @stubs.user.id
-    should.equal user.name, @stubs.user.name
-    should.equal user.real_name, @stubs.user.real_name
-    should.equal user.email_address, @stubs.user.profile.email
-    should.equal user.slack.misc, @stubs.user.misc
-
-    client = new SlackClient {token: 'xoxb-faketoken'}, @stubs.robot
-
-    user_change_event =
-      type: 'user_change'
-      user:
-        id: @stubs.user.id
-        name: 'modified_name'
-        real_name: @stubs.user.real_name
-        profile:
-          email: @stubs.user.profile.email
-
-    @slackbot.updateUserInBrain(user_change_event)
-
-    user = @slackbot.robot.brain.data.users[@stubs.user.id]
-    should.equal user.id, @stubs.user.id
-    should.equal user.name, user_change_event.user.name
-    should.equal user.real_name, @stubs.user.real_name
-    should.equal user.email_address, @stubs.user.profile.email
-    should.equal user.slack.misc, undefined
-    should.equal user.slack.client, undefined
-
-  it 'Should ignore user data which is undefined', ->
-    @slackbot.updateUserInBrain(undefined)
-    users = @slackbot.robot.brain.data.users
-    should.equal Object.keys(users).length, 0
-
   it 'Should load users data from web api', ->
     @slackbot.usersLoaded(null, @stubs.responseUsersList)
 

--- a/test/bot.coffee
+++ b/test/bot.coffee
@@ -135,7 +135,7 @@ describe 'Handling incoming messages', ->
     @stubs.receiveMock.onReceived = (msg) ->
       msg.text.should.equal 'foo'
       done()
-    @slackbot.eventHandler {type: 'message', text: 'foo', user: @stubs.user, channel: @stubs.channel }
+    @slackbot.eventHandler {type: 'message', text: 'foo', user: @stubs.user, channel: @stubs.channel.id }
     return
 
   it 'Should prepend our name to a name-lacking message addressed to us in a DM', ->
@@ -143,7 +143,7 @@ describe 'Handling incoming messages', ->
     @stubs.receiveMock.onReceived = (msg) ->
       msg.text.should.equal "#{bot_name} foo"
       done()
-    @slackbot.eventHandler {type: 'message', text: "foo", user: @stubs.user, channel: @stubs.DM}
+    @slackbot.eventHandler {type: 'message', text: "foo", user: @stubs.user, channel: @stubs.DM.id}
     return
 
   it 'Should NOT prepend our name to a name-containing message addressed to us in a DM', ->
@@ -151,7 +151,7 @@ describe 'Handling incoming messages', ->
     @stubs.receiveMock.onReceived = (msg) ->
       msg.text.should.equal "#{bot_name} foo"
       done()
-    @slackbot.eventHandler {type: 'message', text: "#{bot_name} foo", user: @stubs.user, channel: @stubs.DM}
+    @slackbot.eventHandler {type: 'message', text: "#{bot_name} foo", user: @stubs.user, channel: @stubs.DM.id}
     return
 
   it 'Should return a message object with raw text and message', (done) ->
@@ -160,7 +160,7 @@ describe 'Handling incoming messages', ->
     messageData = {
       type: 'message'
       user: @stubs.user,
-      channel: @stubs.channel,
+      channel: @stubs.channel.id,
       text: 'foo <http://www.example.com> bar',
     }
     @stubs.receiveMock.onReceived = (msg) ->
@@ -236,7 +236,7 @@ describe 'Handling incoming messages', ->
     @stubs.receiveMock.onReceived = (msg) ->
       should.equal (msg instanceof SlackTextMessage), true
       done()
-    @slackbot.eventHandler {type: 'message', subtype: 'bot_message', user: @stubs.user, channel: @stubs.channel, text: 'Pushing is the answer', returnRawText: true }
+    @slackbot.eventHandler {type: 'message', subtype: 'bot_message', user: @stubs.user, channel: @stubs.channel.id, text: 'Pushing is the answer', returnRawText: true }
     return
 
   it 'Should handle single user presence_change events as envisioned', ->
@@ -272,7 +272,7 @@ describe 'Handling incoming messages', ->
     @stubs.receiveMock.onReceived = (msg) ->
       should.equal (msg instanceof SlackTextMessage), true
       done()
-    @slackbot.eventHandler {type: 'message', subtype: 'bot_message', user: undefined, channel: @stubs.channel, text: 'Foo'}
+    @slackbot.eventHandler {type: 'message', subtype: 'bot_message', user: undefined, channel: @stubs.channel.id, text: 'Foo'}
     return
 
   it 'Should handle reaction events from users who are in different workspace in shared channel', ->

--- a/test/client.coffee
+++ b/test/client.coffee
@@ -1,5 +1,6 @@
 {RtmClient, WebClient, MemoryDataStore} = require '@slack/client'
 SlackFormatter = require '../src/formatter'
+SlackClient = require '../src/client'
 should = require 'should'
 _ = require 'lodash'
 
@@ -219,11 +220,76 @@ describe 'loadUsers()', ->
     @client.loadUsers (err, result) =>
       err.should.be.an.Error
 
+describe 'Users data', ->
+  it 'Should add a user data', ->
+    @client.updateUserInBrain(@stubs.user)
+
+    user = @slackbot.robot.brain.data.users[@stubs.user.id]
+    should.equal user.id, @stubs.user.id
+    should.equal user.name, @stubs.user.name
+    should.equal user.real_name, @stubs.user.real_name
+    should.equal user.email_address, @stubs.user.profile.email
+    should.equal user.slack.misc, @stubs.user.misc
+
+  it 'Should add a user data (user with no profile)', ->
+    @client.updateUserInBrain(@stubs.usernoprofile)
+
+    user = @slackbot.robot.brain.data.users[@stubs.usernoprofile.id]
+    should.equal user.id, @stubs.usernoprofile.id
+    should.equal user.name, @stubs.usernoprofile.name
+    should.equal user.real_name, @stubs.usernoprofile.real_name
+    should.equal user.slack.misc, @stubs.usernoprofile.misc
+    (user).should.not.have.ownProperty('email_address')
+
+  it 'Should add a user data (user with no email in profile)', ->
+    @client.updateUserInBrain(@stubs.usernoemail)
+
+    user = @slackbot.robot.brain.data.users[@stubs.usernoemail.id]
+    should.equal user.id, @stubs.usernoemail.id
+    should.equal user.name, @stubs.usernoemail.name
+    should.equal user.real_name, @stubs.usernoemail.real_name
+    should.equal user.slack.misc, @stubs.usernoemail.misc
+    (user).should.not.have.ownProperty('email_address')
+
+  it 'Should modify a user data', ->
+    @client.updateUserInBrain(@stubs.user)
+
+    user = @slackbot.robot.brain.data.users[@stubs.user.id]
+    should.equal user.id, @stubs.user.id
+    should.equal user.name, @stubs.user.name
+    should.equal user.real_name, @stubs.user.real_name
+    should.equal user.email_address, @stubs.user.profile.email
+    should.equal user.slack.misc, @stubs.user.misc
+
+    client = new SlackClient {token: 'xoxb-faketoken'}, @stubs.robot
+
+    user_change_event =
+      type: 'user_change'
+      user:
+        id: @stubs.user.id
+        name: 'modified_name'
+        real_name: @stubs.user.real_name
+        profile:
+          email: @stubs.user.profile.email
+
+    @client.updateUserInBrain(user_change_event)
+
+    user = @slackbot.robot.brain.data.users[@stubs.user.id]
+    should.equal user.id, @stubs.user.id
+    should.equal user.name, user_change_event.user.name
+    should.equal user.real_name, @stubs.user.real_name
+    should.equal user.email_address, @stubs.user.profile.email
+    should.equal user.slack.misc, undefined
+    should.equal user.slack.client, undefined
+
 describe 'fetchBotUser()', ->
   it 'should return user representation from map', ->
-    @client.botUserIdMap[@stubs.bot.id] = @stubs.user
-    result = @client.fetchBotUser @stubs.bot.id
-    result.id.should.equal @stubs.user.id
+    user = @stubs.user
+    @client.botUserIdMap[@stubs.bot.id] = user
+    @client.fetchBotUser @stubs.bot.id
+    .then((res) ->
+      res.id.should.equal user.id
+    )
 
   it 'should return promise if no user representation exists in map', ->
     result = @client.fetchBotUser @stubs.bot.id
@@ -231,10 +297,41 @@ describe 'fetchBotUser()', ->
 
 describe 'fetchUser()', ->
   it 'should return user representation from brain', ->
-    @slackbot.updateUserInBrain(@stubs.user)
-    user = @client.fetchUser @stubs.user.id
-    user.id.should.equal @stubs.user.id
+    user = @stubs.user
+    @client.updateUserInBrain(user)
+    @client.fetchUser user.id
+    .then((res) ->
+      res.id.should.equal user.id
+    )
 
   it 'should return promise if no user exists in brain', ->
     result = @client.fetchUser @stubs.user.id
     result.should.be.Promise()
+
+describe 'fetchConversation()', ->
+  it 'Should remove expired conversation info', ->
+    channel = @stubs.channel
+    client = @client
+    client.channelData[channel.id] = {
+      channel: {id: 'C123', name: 'foo'},
+      updated: @stubs.expired_timestamp
+    }
+    client.fetchConversation channel.id
+    .then((res) ->
+      res.name.should.equal channel.name
+      client.channelData.should.have.key('C123')
+      client.channelData['C123'].channel.name.should.equal channel.name
+    )
+  it 'Should return conversation info if not expired', ->
+    channel = @stubs.channel
+    client = @client
+    client.channelData[channel.id] = {
+      channel: {id: 'C123', name: 'foo'},
+      updated: Date.now()
+    }
+    client.fetchConversation channel.id
+    .then((res) ->
+      res.id.should.equal channel.id
+      client.channelData.should.have.key('C123')
+      client.channelData['C123'].channel.name.should.equal 'foo'
+    )

--- a/test/client.coffee
+++ b/test/client.coffee
@@ -28,7 +28,7 @@ describe 'onEvent()', ->
     @client.onEvent (message) =>
       message.should.be.ok
       message.user.real_name.should.equal @stubs.user.real_name
-      message.channel.name.should.equal @stubs.channel.name
+      message.channel.should.equal @stubs.channel.id
       done()
     # the shape of the following object is a raw RTM message event: https://api.slack.com/events/message
     @client.rtm.emit('message', {
@@ -46,7 +46,7 @@ describe 'onEvent()', ->
     @client.onEvent (message) =>
       message.should.be.ok
       message.user.id.should.equal @stubs.user.id
-      message.channel.name.should.equal @stubs.channel.name
+      message.channel.should.equal @stubs.channel.id
       done()
     # the shape of the following object is a raw RTM message event: https://api.slack.com/events/message
     @client.rtm.emit('message', {
@@ -63,7 +63,7 @@ describe 'onEvent()', ->
   it 'should handle undefined bot users', (done) ->
     @client.onEvent (message) =>
       message.should.be.ok
-      message.channel.name.should.equal @stubs.channel.name
+      message.channel.should.equal @stubs.channel.id
       done()
     @client.rtm.emit('message', {
       type: 'message',

--- a/test/message.coffee
+++ b/test/message.coffee
@@ -122,6 +122,14 @@ describe 'buildText()', ->
       client.channelData.should.have.key('C123')
       client.channelData['C123'].channel.name.should.equal 'baz'
 
+  it 'Should handle conversation errors', ->
+    message = @slacktextmessage_invalid_conversation
+    client = @client
+    message.rawMessage.text = 'foo bar'
+    message.buildText @client, () ->
+      client.robot.logger.logs?.error.length.should.equal 1
+
+
 describe 'replaceLinks()', ->
 
   it 'Should change <@U123> links to @name', ->
@@ -210,4 +218,3 @@ describe 'fetchConversation()', ->
       conversation.id.should.equal channel.id
       conversation.name.should.equal channel.name
     )
-

--- a/test/message.coffee
+++ b/test/message.coffee
@@ -92,7 +92,7 @@ describe 'buildText()', ->
       should.equal (message.mentions[2] instanceof SlackMention), true
 
   it 'Should populate mentions with simple SlackMention object if user in brain', ->
-    @slackbot.updateUserInBrain(@stubs.user)
+    @client.updateUserInBrain(@stubs.user)
     message = @slacktextmessage
     message.rawMessage.text = 'foo <@U123> bar'
     message.buildText @client, () ->
@@ -191,30 +191,3 @@ describe 'replaceLinks()', ->
   it 'Should leave <!foobar> links as-is when no label is provided', ->
     @slacktextmessage.replaceLinks @client, 'foo <!foobar> bar'
     .then((text) -> text.should.equal 'foo <!foobar> bar')
-
-describe 'fetchConversation()', ->
-  it 'Should remove expired conversation info', ->
-    channel = @stubs.channel
-    client = @client
-    client.channelData[channel.id] = {
-      channel: channel,
-      updated: @stubs.expired_timestamp
-    }
-    conversation = @slacktextmessage.fetchConversation client, channel.id
-    .then((res) ->
-      res.channel.id.should.equal channel.id
-      res.channel.name.should.equal channel.name
-      client.channelData.should.be.an.Object().and.be.empty()
-    )
-    
-  it 'Should return conversation info if not expired', ->
-    channel = @stubs.channel
-    @client.channelData[channel.id] = {
-      channel: channel,
-      updated: Date.now()
-    }
-    conversation = @slacktextmessage.fetchConversation @client, channel.id
-    .then((conversation) ->
-      conversation.id.should.equal channel.id
-      conversation.name.should.equal channel.name
-    )

--- a/test/stubs.coffee
+++ b/test/stubs.coffee
@@ -262,7 +262,7 @@ beforeEach ->
 
   @formatter = new SlackFormatter @stubs.client.dataStore, @stubs.robot
 
-  @slacktextmessage = new SlackTextMessage @stubs.self, undefined, undefined, {text: undefined}, undefined, undefined, @slackbot.client
+  @slacktextmessage = new SlackTextMessage @stubs.self, undefined, undefined, {text: undefined}, 'C123', undefined, @slackbot.client
 
   @client = new SlackClient {token: 'xoxb-faketoken'}, @stubs.robot
   _.merge @client.rtm, @stubs.rtm

--- a/test/stubs.coffee
+++ b/test/stubs.coffee
@@ -106,6 +106,7 @@ beforeEach ->
       email: 'org_not_in_workspace@example.com'
   @stubs.team =
     name: 'Example Team'
+  @stubs.expired_timestamp = 1528238205453
 
   # Slack client
   @stubs.client =
@@ -262,7 +263,7 @@ beforeEach ->
 
   @formatter = new SlackFormatter @stubs.client.dataStore, @stubs.robot
 
-  @slacktextmessage = new SlackTextMessage @stubs.self, undefined, undefined, {text: undefined}, 'C123', undefined, @slackbot.client
+  @slacktextmessage = new SlackTextMessage @stubs.self, undefined, undefined, {text: undefined}, @stubs.channel.id, undefined, @slackbot.client
 
   @client = new SlackClient {token: 'xoxb-faketoken'}, @stubs.robot
   _.merge @client.rtm, @stubs.rtm

--- a/test/stubs.coffee
+++ b/test/stubs.coffee
@@ -226,7 +226,6 @@ beforeEach ->
       log: (type, message) ->
         @logs[type] ?= []
         @logs[type].push(message)
-        # console.log "#{type} #{message}"
       info: (message) ->
         @log('info', message)
       debug: (message) ->

--- a/test/stubs.coffee
+++ b/test/stubs.coffee
@@ -265,6 +265,8 @@ beforeEach ->
 
   @slacktextmessage = new SlackTextMessage @stubs.self, undefined, undefined, {text: undefined}, @stubs.channel.id, undefined, @slackbot.client
 
+  @slacktextmessage_invalid_conversation = new SlackTextMessage @stubs.self, undefined, undefined, {text: undefined}, 'C888', undefined, @slackbot.client
+
   @client = new SlackClient {token: 'xoxb-faketoken'}, @stubs.robot
   _.merge @client.rtm, @stubs.rtm
   _.merge @client.web.chat, @stubs.chatMock


### PR DESCRIPTION
###  Summary

Adds a basic cache for conversations and uses user representation in brain for mentions.

Now, conversations will only update if the stored information is older than 5 minutes. This means removing the logic of conversations in `client.coffee` and adding some basic logic into `message.coffee`. This will ensure mostly accurate conversation representations, but decrease the possibility of accidental rate limiting and unnecessary calls to conversations.info.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/hubot-slack/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).