### PR TITLE
Fix attachment flattening inside buildText

### DIFF
--- a/src/message.coffee
+++ b/src/message.coffee
@@ -91,7 +91,7 @@ class SlackTextMessage extends TextMessage
 
     # flatten any attachments into text
     if @rawMessage.attachments
-      attachment_text = @rawMessage.attachments.map(a -> a.fallback).join("\n")
+      attachment_text = @rawMessage.attachments.map((a) -> a.fallback).join("\n")
       text = text + "\n" + attachment_text
 
     # Replace links in text async to fetch user and channel info (if present)

--- a/test/message.coffee
+++ b/test/message.coffee
@@ -129,6 +129,17 @@ describe 'buildText()', ->
     message.buildText @client, () ->
       client.robot.logger.logs?.error.length.should.equal 1
 
+  it 'Should flatten attachments', ->
+    message = @slacktextmessage
+    client = @client
+    message.rawMessage.text = 'foo bar'
+    message.rawMessage.attachments = [
+      { fallback: 'first' },
+      { fallback: 'second' }
+    ]
+    message.buildText @client, () ->
+      message.text.should.equal 'foo bar\nfirst\nsecond'
+
 
 describe 'replaceLinks()', ->
 


### PR DESCRIPTION
###  Summary

there was an issue with the coffeescript syntax that resulted in `a` being treated as a function. this change fixes that.

fixes #500 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/hubot-slack/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).