### PR TITLE
Fix User Object duplication

### DIFF
--- a/src/bot.coffee
+++ b/src/bot.coffee
@@ -236,7 +236,7 @@ class SlackBot extends Adapter
     # real_name {String}:       Name of Slack user or bot
     # room {String}:            Slack channel ID for event (will be empty string if no channel in event)
     ###
-    user = if user? then @client.updateUserInBrain user else {}
+    user = if user? then user else {}
 
     # Send to Hubot based on message type
     if event.type is "message"

--- a/src/bot.coffee
+++ b/src/bot.coffee
@@ -224,20 +224,6 @@ class SlackBot extends Adapter
     # Ignore anything we sent
     return if user?.id is @self.id
 
-    ###*
-    # Hubot user object in Brain.
-    # User can represent a Slack human user or bot user
-    #
-    # The returned user from a message or reaction event is guaranteed to contain:
-    #
-    # id {String}:              Slack user ID
-    # slack.is_bot {Boolean}:   Flag indicating whether user is a bot
-    # name {String}:            Slack username
-    # real_name {String}:       Name of Slack user or bot
-    # room {String}:            Slack channel ID for event (will be empty string if no channel in event)
-    ###
-    user = if user? then user else {}
-
     # Send to Hubot based on message type
     if event.type is "message"
 

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -254,7 +254,18 @@ class SlackClient
     )
 
   ###*
-  # Update user record in the Hubot Brain. This may be called as a handler for `user_change` events or to update a
+  # Will return a Hubot user object in Brain.
+  # User can represent a Slack human user or bot user
+  #
+  # The returned user from a message or reaction event is guaranteed to contain:
+  #
+  # id {String}:              Slack user ID
+  # slack.is_bot {Boolean}:   Flag indicating whether user is a bot
+  # name {String}:            Slack username
+  # real_name {String}:       Name of Slack user or bot
+  # room {String}:            Slack channel ID for event (will be empty string if no channel in event)
+  #
+  # This may be called as a handler for `user_change` events or to update a
   # a single user with its latest SlackUserInfo object.
   #
   # @private
@@ -335,8 +346,10 @@ class SlackClient
             else
               # bot doesn't have an associated user id
               @botUserIdMap[event.bot_id] = false
-          return event
+          else
+            event.user = {}
 
+          return event
         # once the event is fully populated...
         .then (fetchedEvent) =>
           # hand the event off to the eventHandler

--- a/test/bot.coffee
+++ b/test/bot.coffee
@@ -75,16 +75,8 @@ describe 'Disable Sync', ->
     @slackbot.run()
     @slackbot.robot.brain.data.users.should.be.empty()
   
-  it 'Should still sync interacting users when disabled', (done) ->
-    slackbot = @slackbot
-    @stubs.receiveMock.onReceived = (msg) ->
-      msg.text.should.equal 'foo'
-      slackbot.robot.brain.data.users.should.have.keys('U123')
-      done()
-    @slackbot.options.disableUserSync = true
-    @slackbot.run()
-    @slackbot.eventHandler {type: 'message', text: 'foo', user: @stubs.user, channel: @stubs.channel.id }
-    return
+  # Test moved to fetchUsers() in client.coffee because of change in code logic
+  #it 'Should still sync interacting users when disabled'
     
 describe 'Send Messages', ->
 

--- a/test/bot.coffee
+++ b/test/bot.coffee
@@ -311,11 +311,11 @@ describe 'Handling incoming messages', ->
     @slackbot.eventHandler reactionMessage
     should.equal @stubs._received, undefined
 
-  it 'Should handle undefined users as envisioned', (done)->
+  it 'Should handle empty users as envisioned', (done)->
     @stubs.receiveMock.onReceived = (msg) ->
       should.equal (msg instanceof SlackTextMessage), true
       done()
-    @slackbot.eventHandler {type: 'message', subtype: 'bot_message', user: undefined, channel: @stubs.channel.id, text: 'Foo'}
+    @slackbot.eventHandler {type: 'message', subtype: 'bot_message', user: {}, channel: @stubs.channel.id, text: 'Foo'}
     return
 
   it 'Should handle reaction events from users who are in different workspace in shared channel', ->

--- a/test/client.coffee
+++ b/test/client.coffee
@@ -325,7 +325,7 @@ describe 'fetchUser()', ->
     result = @client.fetchUser @stubs.user.id
     result.should.be.Promise()
   
-  it.only 'Should sync interacting users when syncing disabled', ->
+  it 'Should sync interacting users when syncing disabled', ->
     slackbot = @slackbot
     slackbot.options.disableUserSync = true
     slackbot.run()

--- a/test/client.coffee
+++ b/test/client.coffee
@@ -324,6 +324,16 @@ describe 'fetchUser()', ->
   it 'should return promise if no user exists in brain', ->
     result = @client.fetchUser @stubs.user.id
     result.should.be.Promise()
+  
+  it.only 'Should sync interacting users when syncing disabled', ->
+    slackbot = @slackbot
+    slackbot.options.disableUserSync = true
+    slackbot.run()
+
+    @client.fetchUser @stubs.user.id
+    .then((res) ->
+      slackbot.robot.brain.data.users.should.have.keys('U123')
+    )
 
 describe 'fetchConversation()', ->
   it 'Should remove expired conversation info', ->

--- a/test/client.coffee
+++ b/test/client.coffee
@@ -68,7 +68,7 @@ describe 'onEvent()', ->
       done()
     @client.rtm.emit('message', {
       type: 'message',
-      bot_id: 'B789'
+      bot_id: 'B789',
       channel: @stubs.channel.id,
       text: 'blah'
     })
@@ -76,6 +76,23 @@ describe 'onEvent()', ->
     setTimeout(( =>
       @stubs.robot.logger.logs.should.not.have.property('error')
     ), 0);
+
+  it 'should handle undefined users as envisioned', (done) ->
+    @client.onEvent (message) =>
+      message.should.be.ok
+      message.channel.should.equal @stubs.channel.id
+      done()
+    @client.rtm.emit('message', {
+      type: 'message',
+      user: undefined,
+      channel: @stubs.channel.id,
+      text: 'eat more veggies'
+    })
+
+    setTimeout(( =>
+      @stubs.robot.logger.logs.should.not.have.property('error')
+    ), 0);
+
   it 'should update bot id to user representation map', (done) ->
     @client.onEvent (message) =>
       message.should.be.ok


### PR DESCRIPTION
###  Summary

There was an issue where a user representation would have nested `slack` objects inside of them. This prevents that from happening and moves all calls to `@updateUserInBrain` to `client.coffee`.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/hubot-slack/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).