### PR TITLE
Fix unassociated bot user

### DIFF
--- a/src/client.coffee
+++ b/src/client.coffee
@@ -346,6 +346,7 @@ class SlackClient
             else
               # bot doesn't have an associated user id
               @botUserIdMap[event.bot_id] = false
+              event.user = {}
           else
             event.user = {}
 


### PR DESCRIPTION
###  Summary

If a bot user has no association to a user id, make sure it's still defined.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/hubot-slack/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).