### PR TITLE
add properties of ReactionMessage to docs

### DIFF
--- a/docs/_pages/basic_usage.md
+++ b/docs/_pages/basic_usage.md
@@ -207,6 +207,18 @@ module.exports = (robot) ->
         timestamp: res.message.item.ts
 ```
 
+When using `robot.react` as shown above, the `res.message` value is of type `ReactionMessage`. In addition to the normal
+message properties, this type has a few really helpful properties you might want to use in your script:
+
+*  `type`: This is either `"added"` or `"removed"`, depending on whether, you guessed it, the reaction was added or
+   removed.
+*  `reaction`: The name of the emoji reaction. For example, when adding a 👍 reaction, this value is
+   `"thumbsup"`.
+*  `item`: This is either the message, the file, or the comment where this reaction took place.
+*  `item_user`: The user who created the item. This value can be `undefined` if the item was created by a custom
+   integration (not a Slack App).
+*  `event_ts`: The timestamp of when this reaction message took place.
+
 --------
 
 ## Presence changes

--- a/src/message.coffee
+++ b/src/message.coffee
@@ -12,8 +12,9 @@ class ReactionMessage extends Message
   # @param {string} type - A String indicating 'reaction_added' or 'reaction_removed'
   # @param {User} user - A User instance that reacted to the item.
   # @param {string} reaction - A String identifying the emoji reaction.
-  # @param {User} item_user - A String indicating the user that posted the item.
   # @param {Object} item - An Object identifying the target message, file, or comment item.
+  # @param {User} [item_user] - A String indicating the user that posted the item. If the item was created by a
+  # custom integration (not part of a Slack app with a bot user), then this value will be undefined.
   # @param {string} event_ts - A String of the reaction event timestamp.
   ###
   constructor: (@type, @user, @reaction, @item_user, @item, @event_ts) ->


### PR DESCRIPTION
###  Summary

fixes #468

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/hubot-slack/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).