### PR TITLE
swaps out rtm message subtypes for discreet messages for enter and leave

### DIFF
--- a/src/bot.coffee
+++ b/src/bot.coffee
@@ -50,7 +50,7 @@ class SlackBot extends Adapter
       @client.loadUsers @usersLoaded
     else
       @isLoaded = true
-    
+
     # Brain will emit 'loaded' the first time it connects to its storage and then again each time a key is set
     @robot.brain.on "loaded", () =>
       if not @brainIsLoaded
@@ -239,16 +239,6 @@ class SlackBot extends Adapter
             @receive message
           )
 
-        # NOTE: channel_join should be replaced with a member_joined_channel event
-        when "channel_join", "group_join"
-          @robot.logger.debug "Received enter message for user: #{user.id}, joining: #{channel}"
-          @receive new EnterMessage user
-
-        # NOTE: channel_leave should be replaced with a member_left_channel event
-        when "channel_leave", "group_leave"
-          @robot.logger.debug "Received leave message for user: #{user.id}, leaving: #{channel}"
-          @receive new LeaveMessage user
-
         when "channel_topic", "group_topic"
           @robot.logger.debug "Received topic change message in conversation: #{channel}, new topic: #{event.topic}, set by: #{user.id}"
           @receive new TopicMessage user, event.topic, event.ts
@@ -259,6 +249,18 @@ class SlackBot extends Adapter
             return @robot.logger.error "Dropping message due to error #{error.message}" if error
             @receive message
           )
+
+    else if event.type is "member_joined_channel"
+      # this event type always has a channel
+      user.room = channel
+      @robot.logger.debug "Received enter message for user: #{user.id}, joining: #{channel}"
+      @receive new EnterMessage user
+
+    else if event.type is "member_left_channel"
+      # this event type always has a channel
+      user.room = channel
+      @robot.logger.debug "Received leave message for user: #{user.id}, joining: #{channel}"
+      @receive new LeaveMessage user
 
     else if event.type is "reaction_added" or event.type is "reaction_removed"
 

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -50,6 +50,8 @@ class SlackClient
     @rtm.on "reaction_added", @eventWrapper, this
     @rtm.on "reaction_removed", @eventWrapper, this
     @rtm.on "presence_change", @eventWrapper, this
+    @rtm.on "member_joined_channel", @eventWrapper, this
+    @rtm.on "member_left_channel", @eventWrapper, this
     @rtm.on "user_change", @updateUserInBrain, this
     @eventHandler = undefined
 

--- a/test/bot.coffee
+++ b/test/bot.coffee
@@ -74,10 +74,10 @@ describe 'Disable Sync', ->
     @slackbot.options.disableUserSync = true
     @slackbot.run()
     @slackbot.robot.brain.data.users.should.be.empty()
-  
+
   # Test moved to fetchUsers() in client.coffee because of change in code logic
   #it 'Should still sync interacting users when disabled'
-    
+
 describe 'Send Messages', ->
 
   it 'Should send a message', ->
@@ -207,29 +207,19 @@ describe 'Handling incoming messages', ->
     @slackbot.eventHandler messageData
     return
 
-  it 'Should handle channel_join events as envisioned', ->
-    @slackbot.eventHandler {type: 'message', subtype: 'channel_join', user: @stubs.user, channel: @stubs.channel.id}
+  it 'Should handle member_joined_channel events as envisioned', ->
+    @slackbot.eventHandler {type: 'member_joined_channel', user: @stubs.user, channel: @stubs.channel.id}
     should.equal (@stubs._received instanceof EnterMessage), true
     @stubs._received.user.id.should.equal @stubs.user.id
 
-  it 'Should handle channel_leave events as envisioned', ->
-    @slackbot.eventHandler {type: 'message', subtype: 'channel_leave', user: @stubs.user, channel: @stubs.channel.id}
+  it 'Should handle member_left_channel events as envisioned', ->
+    @slackbot.eventHandler {type: 'member_left_channel', user: @stubs.user, channel: @stubs.channel.id}
     should.equal (@stubs._received instanceof LeaveMessage), true
     @stubs._received.user.id.should.equal @stubs.user.id
 
   it 'Should handle channel_topic events as envisioned', ->
     @slackbot.eventHandler {type: 'message', subtype: 'channel_topic', user: @stubs.user, channel: @stubs.channel.id}
     should.equal (@stubs._received instanceof TopicMessage), true
-    @stubs._received.user.id.should.equal @stubs.user.id
-
-  it 'Should handle group_join events as envisioned', ->
-    @slackbot.eventHandler {type: 'message', subtype: 'group_join', user: @stubs.user, channel: @stubs.channel.id}
-    should.equal (@stubs._received instanceof EnterMessage), true
-    @stubs._received.user.id.should.equal @stubs.user.id
-
-  it 'Should handle group_leave events as envisioned', ->
-    @slackbot.eventHandler {type: 'message', subtype: 'group_leave', user: @stubs.user, channel: @stubs.channel.id}
-    should.equal (@stubs._received instanceof LeaveMessage), true
     @stubs._received.user.id.should.equal @stubs.user.id
 
   it 'Should handle group_topic events as envisioned', ->


### PR DESCRIPTION
###  Summary

fixes #296

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/hubot-slack/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).