### PR TITLE
One way to fix bot_not_found due to SlackBot

### DIFF
--- a/src/client.coffee
+++ b/src/client.coffee
@@ -225,6 +225,7 @@ class SlackClient
   # @public
   ###
   fetchBotUser: (botId) ->
+    return Promise.resolve(false) if (botId == "B01")
     return Promise.resolve(@botUserIdMap[botId]) if @botUserIdMap[botId]?
 
     # Bot user is not in mapping - call bots.info

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -39,7 +39,9 @@ class SlackClient
 
     # Map to convert bot user IDs (BXXXXXXXX) to user representations for events from custom
     # integrations and apps without a bot user
-    @botUserIdMap = {}
+    @botUserIdMap = {
+      "B01": { id: "B01", user_id: "USLACKBOT" }
+    }
 
     # Map to convert conversation IDs to conversation representations
     @channelData = {}
@@ -225,7 +227,6 @@ class SlackClient
   # @public
   ###
   fetchBotUser: (botId) ->
-    return Promise.resolve(false) if (botId == "B01")
     return Promise.resolve(@botUserIdMap[botId]) if @botUserIdMap[botId]?
 
     # Bot user is not in mapping - call bots.info

--- a/test/client.coffee
+++ b/test/client.coffee
@@ -312,10 +312,11 @@ describe 'fetchBotUser()', ->
     result = @client.fetchBotUser @stubs.bot.id
     result.should.be.Promise()
 
-  it 'should return false if id is slackbots id', ->
+  it 'should return constant data if id is slackbots id', ->
     @client.fetchBotUser @stubs.slack_bot.id
     .then((res) ->
-      res.should.equal false
+      res.id.should.equal @stubs.slack_bot.id
+      res.user_id.should.equal @stubs.slack_bot.user_id
     )
 
 describe 'fetchUser()', ->

--- a/test/client.coffee
+++ b/test/client.coffee
@@ -312,6 +312,12 @@ describe 'fetchBotUser()', ->
     result = @client.fetchBotUser @stubs.bot.id
     result.should.be.Promise()
 
+  it 'should return false if id is slackbots id', ->
+    @client.fetchBotUser @stubs.slack_bot.id
+    .then((res) ->
+      res.should.equal false
+    )
+
 describe 'fetchUser()', ->
   it 'should return user representation from brain', ->
     user = @stubs.user

--- a/test/client.coffee
+++ b/test/client.coffee
@@ -313,10 +313,11 @@ describe 'fetchBotUser()', ->
     result.should.be.Promise()
 
   it 'should return constant data if id is slackbots id', ->
+    user = @stubs.slack_bot
     @client.fetchBotUser @stubs.slack_bot.id
     .then((res) ->
-      res.id.should.equal @stubs.slack_bot.id
-      res.user_id.should.equal @stubs.slack_bot.user_id
+      res.id.should.equal user.id
+      res.user_id.should.equal user.user_id
     )
 
 describe 'fetchUser()', ->

--- a/test/stubs.coffee
+++ b/test/stubs.coffee
@@ -83,6 +83,10 @@ beforeEach ->
   @stubs.undefined_user_bot =
     name: 'testbot'
     id: 'B789'
+  @stubs.slack_bot =
+    name: 'slackbot'
+    id: 'B01'
+    user_id: 'USLACKBOT'
   @stubs.self =
     name: 'self'
     id: 'U456'


### PR DESCRIPTION
fixes #519
Specifically when /remind is setup to trigger a hubot event

###  Summary

Prevent `bot_not_found` when looking up SlackBot using `bots.info` with id:B01 from causing an error that stops execution of listeners

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/hubot-slack/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).