### PR TITLE
Upgrade lodash to the latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@slack/client": "3.16.1-sec",
     "bluebird": "^3.5.1",
-    "lodash": "^3.10.1"
+    "lodash": "^4.17.10"
   },
   "peerDependencies": {
     "hubot": "^2.0.0"


### PR DESCRIPTION
###  Summary

This upgrades to the latest lodash; the version in `package.json` was a major release behind. The tests pass with this new version.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/hubot-slack/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).