### PR TITLE
Fix tests on new hubot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,9 @@ node_js:
   - "5"
   - "4"
   - "4.2"
+env:
+  - HUBOT_VERSION=">=2.0 <3"
+  - HUBOT_VERSION="^3.0"
 after_success:
   - npm run codecov
+script: npm install && npm install hubot@"$HUBOT_VERSION" && npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,8 @@ env:
   - HUBOT_VERSION="^3.0"
 after_success:
   - npm run codecov
+# The second step here installs the specific hubot version determined
+# by the `env` specified in the matrix. That lets us test against
+# multiple Hubot versions. This is a bit messy, but works around
+# package.json only being able to specify one version.
 script: npm install && npm install hubot@"$HUBOT_VERSION" && npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,5 @@ node_js:
   - "5"
   - "4"
   - "4.2"
-  - "0.12"
 after_success:
   - npm run codecov

--- a/package.json
+++ b/package.json
@@ -29,14 +29,14 @@
     "lodash": "^4.17.10"
   },
   "peerDependencies": {
-    "hubot": "^2.0.0"
+    "hubot": ">= 2.0.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",
     "coffee-coverage": "^2.0.0",
     "coffeescript": "^1.12.7",
     "codecov": "^2.3.1",
-    "hubot": "^2.19.0",
+    "hubot": ">= 2.19.0",
     "istanbul": "^0.4.3",
     "mocha": "^3.5.3",
     "should": "^8.0.0"

--- a/test/bot.coffee
+++ b/test/bot.coffee
@@ -209,22 +209,22 @@ describe 'Handling incoming messages', ->
 
   it 'Should handle member_joined_channel events as envisioned', ->
     @slackbot.eventHandler {type: 'member_joined_channel', user: @stubs.user, channel: @stubs.channel.id}
-    should.equal (@stubs._received instanceof EnterMessage), true
+    should.equal @stubs._received.constructor.name, "EnterMessage"
     @stubs._received.user.id.should.equal @stubs.user.id
 
   it 'Should handle member_left_channel events as envisioned', ->
     @slackbot.eventHandler {type: 'member_left_channel', user: @stubs.user, channel: @stubs.channel.id}
-    should.equal (@stubs._received instanceof LeaveMessage), true
+    should.equal @stubs._received.constructor.name, "LeaveMessage"
     @stubs._received.user.id.should.equal @stubs.user.id
 
   it 'Should handle channel_topic events as envisioned', ->
     @slackbot.eventHandler {type: 'message', subtype: 'channel_topic', user: @stubs.user, channel: @stubs.channel.id}
-    should.equal (@stubs._received instanceof TopicMessage), true
+    should.equal @stubs._received.constructor.name, "TopicMessage"
     @stubs._received.user.id.should.equal @stubs.user.id
 
   it 'Should handle group_topic events as envisioned', ->
     @slackbot.eventHandler {type: 'message', subtype: 'group_topic', user: @stubs.user, channel: @stubs.channel.id}
-    should.equal (@stubs._received instanceof TopicMessage), true
+    should.equal @stubs._received.constructor.name, "TopicMessage"
     @stubs._received.user.id.should.equal @stubs.user.id
 
   it 'Should handle reaction_added events as envisioned', ->


### PR DESCRIPTION
###  Summary

This fixes running the tests with Hubot 3.x.

I was seeing these four `instanceof` tests fail. I believe the reason for this is that Hubot 3.x is written in JavaScript using ES2015 classes, and there's a subtle issue with `instanceof` not playing nicely when CoffeeScript classes enter the picture.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/hubot-slack/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).