### PR TITLE
WIP: add compatibility for Coffeescript 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "coffee-coverage": "^2.0.0",
-    "coffeescript": "^1.12.7",
+    "coffeescript": "^2.3.1",
     "codecov": "^2.3.1",
     "hubot": "^2.19.0",
     "istanbul": "^0.4.3",

--- a/src/bot.coffee
+++ b/src/bot.coffee
@@ -16,7 +16,7 @@ class SlackBot extends Adapter
   # @param {Object} options.rtmStart - options for `rtm.start` Web API method
   ###
   constructor: (@robot, @options) ->
-    super
+    super()
     @robot.logger.info "hubot-slack adapter v#{pkg.version}"
     @client = new SlackClient @options, @robot
 

--- a/src/message.coffee
+++ b/src/message.coffee
@@ -17,8 +17,9 @@ class ReactionMessage extends Message
   # custom integration (not part of a Slack app with a bot user), then this value will be undefined.
   # @param {string} event_ts - A String of the reaction event timestamp.
   ###
-  constructor: (@type, @user, @reaction, @item_user, @item, @event_ts) ->
-    super @user
+  constructor: (@type, user, @reaction, @item_user, @item, @event_ts) ->
+    super user
+    @user = user
     @type = @type.replace("reaction_", "")
 
 class PresenceMessage extends Message
@@ -66,7 +67,13 @@ class SlackTextMessage extends TextMessage
   # @param {string} robot_name - The Slack username for this robot
   # @param {string} robot_alias - The alias for this robot
   ###
-  constructor: (@user, @text, rawText, @rawMessage, channel_id, robot_name, robot_alias) ->
+  constructor: (user, text, rawText, rawMessage, channel_id, robot_name, robot_alias) ->
+    super user, text, rawMessage.ts
+
+    @user = user
+    @text = text
+    @rawMessage = rawMessage
+
     # private instance properties
     @_channel_id = channel_id
     @_robot_name = robot_name
@@ -76,8 +83,6 @@ class SlackTextMessage extends TextMessage
     @rawText = rawText || @rawMessage.text
     @thread_ts = @rawMessage.thread_ts if @rawMessage.thread_ts?
     @mentions = []
-
-    super @user, @text, @rawMessage.ts
 
   ###*
   # Build the text property, a flat string representation of the contents of this message.


### PR DESCRIPTION
###  Summary

This PR starts the work on making sure the classes in this code work in Coffeescript 2. As mentioned previously, a few of the semantic differences between Coffeescript 1 classes and ES2015 classes has introduced some backwards compatibility issues, documented here: https://coffeescript.org/#breaking-changes

Currently, this mostly works, but trying to actually launch Hubot fails with a `TypeError: Cannot read property 'bind' of undefined` error. I believe this *may* be because of the following:

> ES2015 classes don’t allow bound (fat arrow) methods. The CoffeeScript compiler goes through some contortions to preserve support for them, but one thing that can’t be accommodated is calling a bound method before it is bound

refs #526.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/hubot-slack/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).