### PR TITLE
Imports Hubot prototype dynamically for extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,12 +33,13 @@
   },
   "devDependencies": {
     "chai": "^3.5.0",
+    "codecov": "^2.3.1",
     "coffee-coverage": "^2.0.0",
     "coffeescript": "^1.12.7",
-    "codecov": "^2.3.1",
     "hubot": ">= 2.19.0",
     "istanbul": "^0.4.3",
     "mocha": "^3.5.3",
+    "mockery": "^2.1.0",
     "should": "^8.0.0"
   },
   "engines": {

--- a/src/extensions.coffee
+++ b/src/extensions.coffee
@@ -1,4 +1,9 @@
 {Robot}           = require.main.require "hubot"
+
+# Requires the es2015 version of Hubot for v3 or higher so the correct prototype is updated
+if Robot.name == "CoffeeScriptCompatibleClass"
+  {Robot} = require.main.require "hubot/es2015"
+
 {ReactionMessage, PresenceMessage} = require "./message"
 
 ###*

--- a/test/bot.coffee
+++ b/test/bot.coffee
@@ -1,27 +1,32 @@
 should = require 'should'
 chai = require 'chai'
-{ EnterMessage, LeaveMessage, TopicMessage, CatchAllMessage, Robot } = require.main.require 'hubot'
+mockery = require 'mockery'
+hubotSlackMock = require '../slack.coffee'
+mockery.registerMock('hubot-slack', hubotSlackMock);
+
+{ EnterMessage, LeaveMessage, TopicMessage, CatchAllMessage, Robot, loadBot } = require.main.require 'hubot'
 { SlackTextMessage, ReactionMessage, PresenceMessage } = require '../src/message'
 SlackClient = require '../src/client'
 _ = require 'lodash'
 
 describe 'Adapter', ->
+  before ->
+    mockery.enable({
+      warnOnUnregistered: false
+    });
+  
+  after ->
+    mockery.disable()
+  
   it 'Should initialize with a robot', ->
     @slackbot.robot.should.eql @stubs.robot
 
-  it 'Should add the `react` method to the hubot `Robot` prototype', ->
-    Robot.prototype.react.should.be.an.instanceOf(Function).with.lengthOf(3)
-
-    # This is a sanity check to ensure the @slackbot.robot stub is proper.
-    @slackbot.robot.listen.should.be.an.instanceOf(Function).with.lengthOf(3)
-    @slackbot.robot.react.should.be.an.instanceOf(Function).with.lengthOf(3)
-
-  it 'Should add the `presenceChange` method to the hubot `Robot` prototype', ->
-    Robot.prototype.presenceChange.should.be.an.instanceOf(Function).with.lengthOf(3)
-
-    # This is a sanity check to ensure the @slackbot.robot stub is proper.
-    @slackbot.robot.listen.should.be.an.instanceOf(Function).with.lengthOf(3)
-    @slackbot.robot.presenceChange.should.be.an.instanceOf(Function).with.lengthOf(3)
+  it 'Should load an instance of Robot with extended methods', ->
+    loadedRobot = loadBot('', 'slack', false, 'Hubot')
+    
+    # Check to make sure presenceChange and react are loaded to Robot
+    loadedRobot.presenceChange.should.be.an.instanceOf(Function).with.lengthOf(3)
+    loadedRobot.react.should.be.an.instanceOf(Function).with.lengthOf(3)
 
 describe 'Connect', ->
   it 'Should connect successfully', ->


### PR DESCRIPTION
###  Summary

Hubot `v3.0.0` updated the source to `es2015`, which includes implementing a coffeescript-compatible wrapper to not break adapters. However, this meant that we were adding our extensions (`hearReaction` and `presenceChange`) to the coffeescript wrapper rather than the `Robot` prototype. This fixes that by checking `robot.name` (which is `CoffeeScriptCompatibleClass` for Hubot `v3.0.0` or higher) and importing the proper hubot based on that.

Fixes #538 and #537 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/hubot-slack/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).