### PR TITLE
WIP: Update bot code to log the content of the received text message

### DIFF
--- a/src/bot.coffee
+++ b/src/bot.coffee
@@ -236,6 +236,7 @@ class SlackBot extends Adapter
           @robot.logger.debug "Received text message in channel: #{channel}, from: #{user.id} (bot)"
           SlackTextMessage.makeSlackTextMessage(user, undefined, undefined, event, channel, @robot.name, @robot.alias, @client, (error, message) =>
             return @robot.logger.error "Dropping message due to error #{error.message}" if error
+            @robot.logger.debug "Received text message in channel: #{channel}, from: #{user.id} (bot), message: #(message.text)"
             @receive message
           )
 
@@ -247,6 +248,7 @@ class SlackBot extends Adapter
           @robot.logger.debug "Received text message in channel: #{channel}, from: #{user.id} (human)"
           SlackTextMessage.makeSlackTextMessage(user, undefined, undefined, event, channel, @robot.name, @robot.alias, @client, (error, message) =>
             return @robot.logger.error "Dropping message due to error #{error.message}" if error
+            @robot.logger.debug "Received text message in channel: #{channel}, from: #{user.id} (human), message: #(message.text)"
             @receive message
           )
 


### PR DESCRIPTION
###  Summary

This pull request updates bot code to log the actual received message content inside the event handler.

Keep in mind that the code is not the final version. I just opened the PR and included something to get the discussions going and I'm open to improving / changing it.

### Context, Background

Older versions of hubot-slack logged the actual message content, but the newer ones don't.

Older versions:

```bash
...
[Tue Nov 13 2018 17:22:34 GMT+0000 (UTC)] DEBUG No listeners executed; falling back to catch-all
[Tue Nov 13 2018 17:22:35 GMT+0000 (UTC)] DEBUG Received message: '
Action st2.executions.get completed.
...
```

Recent versions:

```bash
...
[Tue Nov 13 2018 17:26:28 GMT+0000 (Coordinated Universal Time)] DEBUG SlackClient#send() room: C066X08KY, message: [object Object]
[Tue Nov 13 2018 17:26:29 GMT+0000 (Coordinated Universal Time)] DEBUG Received text message in channel: C066X08KY, from: U6L3A6MK7 (human)
[Tue Nov 13 2018 17:26:29 GMT+0000 (Coordinated Universal Time)] DEBUG No listeners executed; falling back to catch-all' does not contain 'details available at'
...
```

Not having the direct access to the message content makes debugging and other things harder / impossible. We also have some tests which need to assert on the raw text message value and recent versions make that impossible.

The message content is logged under ``debug`` log level (same as in the past) so it should have no "negative" security implications or consequences (even if the message contains sensitive data, that's the whole point of the debug log level - to log as much context as possible to make debugging easier / possible and debug shouldn't be used in production).

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/hubot-slack/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).