### PR TITLE
update dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,12 +33,12 @@
   },
   "devDependencies": {
     "chai": "^3.5.0",
-    "codecov": "^2.3.1",
+    "codecov": "^3.2.0",
     "coffee-coverage": "^2.0.0",
     "coffeescript": "^1.12.7",
     "hubot": ">= 2.19.0",
     "istanbul": "^0.4.3",
-    "mocha": "^3.5.3",
+    "mocha": "^4.1.0",
     "mockery": "^2.1.0",
     "should": "^8.0.0"
   },


### PR DESCRIPTION
This updates the dev dependencies just enough to get a clean `npm
audit`.

###  Summary

mocha and codecov dev dependencies are out of date, resulting in scary warnings from recent versions of npm. This fixes those issues.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/hubot-slack/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).