### PR TITLE
fix issue with using a string from env vars as a number

### DIFF
--- a/src/client.coffee
+++ b/src/client.coffee
@@ -13,13 +13,16 @@ class SlackClient
   ###*
   # Number of milliseconds which the information returned by `conversations.info` is considered to be valid. The default
   # value is 5 minutes, and it can be customized by setting the `HUBOT_SLACK_CONVERSATION_CACHE_TTL_MS` environment
-  # variable. Setting this number higher will reduce the number of requests made to the Web API, which may be helpful
-  # if your Hubot is experiencing rate limiting errors. However, setting this number too high will result in stale data
+  # variable. Setting this number higher will reduce the number of requests made to the Web API, which may be helpful if
+  # your Hubot is experiencing rate limiting errors. However, setting this number too high will result in stale data
   # being referenced, and your scripts may experience errors related to channel info (like the name) being incorrect
   # after a user changes it in Slack.
   # @private
   ###
-  @CONVERSATION_CACHE_TTL_MS = process.env.HUBOT_SLACK_CONVERSATION_CACHE_TTL_MS || (5 * 60 * 1000)
+  @CONVERSATION_CACHE_TTL_MS =
+    if process.env.HUBOT_SLACK_CONVERSATION_CACHE_TTL_MS
+    then parseInt(process.env.HUBOT_SLACK_CONVERSATION_CACHE_TTL_MS, 10)
+    else (5 * 60 * 1000)
 
   ###*
   # @constructor

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -398,4 +398,7 @@ class SlackClient
 # @param {Array<SlackUserInfo>} results.members
 ###
 
+if SlackClient.CONVERSATION_CACHE_TTL_MS is NaN
+  throw new Error('HUBOT_SLACK_CONVERSATION_CACHE_TTL_MS must be a number. It could not be parsed.')
+
 module.exports = SlackClient


### PR DESCRIPTION
###  Summary

In #560, we failed to convert the value from a string to a number, so that it could be used as the TTL. This PR fixes that problem.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/hubot-slack/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).