### PR TITLE
Add compatibility for Coffeescript 2 (and hubot 3)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,4 @@ after_success:
 # by the `env` specified in the matrix. That lets us test against
 # multiple Hubot versions. This is a bit messy, but works around
 # package.json only being able to specify one version.
-script:
-  - npm install &&\
-    npm install hubot@"$HUBOT_VERSION" coffeescript@"$COFFEESCRIPT_VERSION" &&\
-    npm test
+script: npm install && npm install hubot@"$HUBOT_VERSION" coffeescript@"$COFFEESCRIPT_VERSION" && npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ env:
   - HUBOT_VERSION=">=2.0 <3" COFFEESCRIPT_VERSION=">=1.6.3 <2.0"
   - HUBOT_VERSION="^3.0" COFFEESCRIPT_VERSION=">=1.6.3 <2.0"
   - HUBOT_VERSION="^3.0" COFFEESCRIPT_VERSION="^2.0"
+# Excluding tests with Coffeescript 2 on nodejs version <= 5
+# because the syntax incompatible issue. Coffeescript 2 use
+# destructuring assignment syntax at https://git.io/fjcq2 but
+# nodejs <= 5 doesn't support.
 matrix:
   exclude:
     - node_js: "4.2"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,16 @@ node_js:
   - "4"
   - "4.2"
 env:
-  - HUBOT_VERSION=">=2.0 <3"
-  - HUBOT_VERSION="^3.0"
+  - HUBOT_VERSION=">=2.0 <3" COFFEESCRIPT_VERSION=">=1.6.3 <2.0"
+  - HUBOT_VERSION="^3.0" COFFEESCRIPT_VERSION=">=1.6.3 <2.0"
+  - HUBOT_VERSION="^3.0" COFFEESCRIPT_VERSION="^2.0"
 after_success:
   - npm run codecov
 # The second step here installs the specific hubot version determined
 # by the `env` specified in the matrix. That lets us test against
 # multiple Hubot versions. This is a bit messy, but works around
 # package.json only being able to specify one version.
-script: npm install && npm install hubot@"$HUBOT_VERSION" && npm test
+script:
+  - npm install &&\
+    npm install hubot@"$HUBOT_VERSION" coffeescript@"$COFFEESCRIPT_VERSION" &&\
+    npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,14 @@ env:
   - HUBOT_VERSION=">=2.0 <3" COFFEESCRIPT_VERSION=">=1.6.3 <2.0"
   - HUBOT_VERSION="^3.0" COFFEESCRIPT_VERSION=">=1.6.3 <2.0"
   - HUBOT_VERSION="^3.0" COFFEESCRIPT_VERSION="^2.0"
+matrix:
+  exclude:
+    - node_js: "4.2"
+      env: HUBOT_VERSION="^3.0" COFFEESCRIPT_VERSION="^2.0"
+    - node_js: "4"
+      env: HUBOT_VERSION="^3.0" COFFEESCRIPT_VERSION="^2.0"
+    - node_js: "5"
+      env: HUBOT_VERSION="^3.0" COFFEESCRIPT_VERSION="^2.0"
 after_success:
   - npm run codecov
 # The second step here installs the specific hubot version determined

--- a/src/bot.coffee
+++ b/src/bot.coffee
@@ -16,7 +16,7 @@ class SlackBot extends Adapter
   # @param {Object} options.rtmStart - options for `rtm.start` Web API method
   ###
   constructor: (robot, @options) ->
-    super(robot)
+    super robot
     @robot = robot
     @robot.logger.info "hubot-slack adapter v#{pkg.version}"
     @client = new SlackClient @options, @robot

--- a/src/bot.coffee
+++ b/src/bot.coffee
@@ -15,8 +15,9 @@ class SlackBot extends Adapter
   # @param {Object} options.rtm - RTM configuration options for SlackClient
   # @param {Object} options.rtmStart - options for `rtm.start` Web API method
   ###
-  constructor: (@robot, @options) ->
-    super
+  constructor: (robot, @options) ->
+    super(robot)
+    @robot = robot
     @robot.logger.info "hubot-slack adapter v#{pkg.version}"
     @client = new SlackClient @options, @robot
 
@@ -287,9 +288,9 @@ class SlackBot extends Adapter
 
       @robot.logger.debug "Received presence update message for users: #{u.id for u in users} with status: #{event.presence}"
       @receive new PresenceMessage(users, event.presence)
-      
+
     else if event.type is "file_shared"
-    
+
       # Once again Hubot expects all user objects to have a room property that is used in the envelope for the message
       # after it is received. If the reaction is to a message, then the `event.item.channel` contain a conversation ID.
       # Otherwise reactions can be on files and file comments, which are "global" and aren't contained in a

--- a/src/message.coffee
+++ b/src/message.coffee
@@ -17,10 +17,11 @@ class ReactionMessage extends Message
   # custom integration (not part of a Slack app with a bot user), then this value will be undefined.
   # @param {string} event_ts - A String of the reaction event timestamp.
   ###
-  constructor: (@type, @user, @reaction, @item_user, @item, @event_ts) ->
-    super @user
+  constructor: (@type, user, @reaction, @item_user, @item, @event_ts) ->
+    super user
+    @user = user
     @type = @type.replace("reaction_", "")
-    
+
 class FileSharedMessage extends Message
 
   ###*
@@ -31,8 +32,9 @@ class FileSharedMessage extends Message
   # @param {string} file_id - A String identifying the file_id of the file that was shared.
   # @param {string} event_ts - A String of the file_shared event timestamp.
   ###
-  constructor: (@user, @file_id, @event_ts) ->
-    super @user
+  constructor: (user, @file_id, @event_ts) ->
+    super user
+    @user = user
 
 class PresenceMessage extends Message
 
@@ -79,7 +81,12 @@ class SlackTextMessage extends TextMessage
   # @param {string} robot_name - The Slack username for this robot
   # @param {string} robot_alias - The alias for this robot
   ###
-  constructor: (@user, @text, rawText, @rawMessage, channel_id, robot_name, robot_alias) ->
+  constructor: (user, text, rawText, rawMessage, channel_id, robot_name, robot_alias) ->
+    super user, text, rawMessage.ts
+
+    @user = user
+    @text = text
+    @rawMessage = rawMessage
     # private instance properties
     @_channel_id = channel_id
     @_robot_name = robot_name
@@ -89,8 +96,6 @@ class SlackTextMessage extends TextMessage
     @rawText = rawText || @rawMessage.text
     @thread_ts = @rawMessage.thread_ts if @rawMessage.thread_ts?
     @mentions = []
-
-    super @user, @text, @rawMessage.ts
 
   ###*
   # Build the text property, a flat string representation of the contents of this message.


### PR DESCRIPTION
###  Summary

This PR continues https://github.com/slackapi/hubot-slack/pull/528 works.
Make sure the classes in this code work in Coffeescript 2 (and with hubot 3).

A few of the semantic differences between Coffeescript 1 classes and ES2015 classes has introduced some backwards compatibility issues, as follows:
[Breaking Changes From CoffeeScript 1.x to 2](https://coffeescript.org/#unsupported-get-set)

Known Issue: This PR doesn't make hubot-slack work with hubot 2 in Coffeescript 2. Because hubot 2 still based on Coffeescript 1.

Refs: https://github.com/slackapi/hubot-slack/issues/526

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/hubot-slack/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).