### PR TITLE
WIP: Emit debugging events

### DIFF
--- a/src/bot.coffee
+++ b/src/bot.coffee
@@ -200,6 +200,8 @@ class SlackBot extends Adapter
     # NOTE: should rate limit errors also bubble up?
     if error.code isnt -1
       @robot.emit "error", error
+    else
+      @robot.emit "slack-rate-limit"
 
   ###*
   # Incoming Slack event handler

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -192,10 +192,13 @@ class SlackClient
       thread_ts: envelope.message?.thread_ts
 
     if typeof message isnt "string"
-      @web.chat.postMessage(room, message.text, _.defaults(message, options))
+      messageOptions = _.defaults(message, options)
+      @robot.emit "postMessage", room, message.text, messageOptions
+      @web.chat.postMessage(room, message.text, messageOptions)
         .catch (error) =>
           @robot.logger.error "SlackClient#send() error: #{error.message}"
     else
+      @robot.emit "postMessage", room, message, options
       @web.chat.postMessage(room, message, options)
         .catch (error) =>
           @robot.logger.error "SlackClient#send() error: #{error.message}"


### PR DESCRIPTION
###  Summary

My company's Hubot has been facing some repeated rate-limiting issues, and we've found that hubot-slack has been missing the diagnostics we need to be able to figure out the cause. This adds some new event emitters to let user scripts listen in for these events. So far I've added emitters for every message that's posted, and whenever a rate limit occurs.

An open question for me on the latter is whether there's any other place that rate limiting might come up, and whether there's any detail that I can include in the `slack-rate-limit` event in order to allow consumers to gather meaningful, actionable data.

cc @aoberoi 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/hubot-slack/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).