### PR TITLE
Remove deprecated mocha --compilers option

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,8 +11,8 @@
       "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
       "stopOnEntry": false,
       "args": [
-        "--compilers",
-        "coffee:coffeescript/register",
+        "--require",
+        "coffeescript/register",
         "--no-timeouts"
       ],
       "cwd": "${workspaceFolder}",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "npm run mocha && istanbul report text-summary lcov",
     "codecov": "codecov",
-    "mocha": "mocha --compilers coffee:coffeescript/register --require coffee-coverage/register-istanbul --reporter spec test"
+    "mocha": "mocha --require coffeescript/register --require coffee-coverage/register-istanbul --reporter spec test/*.coffee"
   },
   "keywords": [
     "hubot",


### PR DESCRIPTION
###  Summary

This option has been deprecated, but a simple `--require` will do the job just as well. See:
https://github.com/mochajs/mocha/wiki/compilers-deprecation

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/hubot-slack/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).