### PR TITLE
Bot: catch and react to disconnection event

### DIFF
--- a/src/bot.coffee
+++ b/src/bot.coffee
@@ -37,6 +37,7 @@ class SlackBot extends Adapter
     # SlackClient event handlers
     @client.rtm.on "open", @open
     @client.rtm.on "close", @close
+    @client.rtm.on "disconnect", @disconnect
     @client.rtm.on "error", @error
     @client.rtm.on "authenticated", @authenticated
     @client.onEvent @eventHandler
@@ -177,16 +178,24 @@ class SlackBot extends Adapter
   # @private
   ###
   close: =>
-    @robot.logger.info "Disconnected from Slack RTM"
     # NOTE: not confident that @options.autoReconnect works
     if @options.autoReconnect
+      @robot.logger.info "Disconnected from Slack RTM"
       @robot.logger.info "Waiting for reconnect..."
     else
-      @robot.logger.info "Exiting..."
-      @client.disconnect()
-      # NOTE: Node recommends not to call process.exit() but Hubot itself uses this mechanism for shutting down
-      # Can we make sure the brain is flushed to persistence? Do we need to cleanup any state (or timestamp anything)?
-      process.exit 1
+      @disconnect()
+
+  ###*
+  # Slack client has closed the connection and will not reconnect
+  # @private
+  ###
+  disconnect: =>
+    @robot.logger.info "Disconnected from Slack RTM"
+    @robot.logger.info "Exiting..."
+    @client.disconnect()
+    # NOTE: Node recommends not to call process.exit() but Hubot itself uses this mechanism for shutting down
+    # Can we make sure the brain is flushed to persistence? Do we need to cleanup any state (or timestamp anything)?
+    process.exit 1
 
   ###*
   # Slack client received an error


### PR DESCRIPTION
###  Summary

As described in #536, hubot-slack sometimes appears to disconnect and never come back. There is a [`disconnect` event](https://github.com/slackapi/node-slack-sdk/blob/13248f403758d7158c1bafe5db009e3f0416b4b8/lib/clients/events/client.js#L26-L27) which occurs specifically when the RTM client has disconnected and will not try again; this is currently not handled by the codebase, so that would explain why what we're seeing is going uncaught. In this PR, I've added a new handler for that method; right now I'm having that close the bot entirely, allowing the running process manager to clean up and restart Hubot.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/hubot-slack/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).