### PR TITLE
WIP: Bot: support bubbling up rate limit info

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ after_success:
 # by the `env` specified in the matrix. That lets us test against
 # multiple Hubot versions. This is a bit messy, but works around
 # package.json only being able to specify one version.
-script: npm install && npm install hubot@"$HUBOT_VERSION" && npm test
+install: npm install && npm install -dd hubot@"$HUBOT_VERSION"

--- a/src/bot.coffee
+++ b/src/bot.coffee
@@ -3,7 +3,7 @@
 SlackClient                                                                       = require "./client"
 pkg                                                                               = require "../package"
 
-Events      = require("@slack/client").CLIENT_EVENTS
+Events                                                                            = require("@slack/client").CLIENT_EVENTS
 
 class SlackBot extends Adapter
 

--- a/src/bot.coffee
+++ b/src/bot.coffee
@@ -3,6 +3,8 @@
 SlackClient                                                                       = require "./client"
 pkg                                                                               = require "../package"
 
+Events      = require("@slack/client").CLIENT_EVENTS
+
 class SlackBot extends Adapter
 
   ###*
@@ -39,6 +41,7 @@ class SlackBot extends Adapter
     @client.rtm.on "close", @close
     @client.rtm.on "disconnect", @disconnect
     @client.rtm.on "error", @error
+    @client.web.on Events.WEB.RATE_LIMITED, @rate_limited
     @client.rtm.on "authenticated", @authenticated
     @client.onEvent @eventHandler
 
@@ -206,9 +209,20 @@ class SlackBot extends Adapter
   error: (error) =>
     @robot.logger.error "Slack RTM error: #{JSON.stringify error}"
     # Assume that scripts can handle slowing themselves down, all other errors are bubbled up through Hubot
-    # NOTE: should rate limit errors also bubble up?
     if error.code isnt -1
       @robot.emit "error", error
+    else
+      # The actual duration of the rate limit isn't exposed. :(
+      @rate_limited(-1)
+
+  ###*
+  # Bubbles up rate-limit info, allowing the bot to react
+  #
+  # @private
+  # @param {number seconds}
+  ###
+  rate_limited: (seconds) ->
+    @robot.emit "slack-rate-limit", seconds
 
   ###*
   # Incoming Slack event handler


### PR DESCRIPTION
###  Summary

This exposes Slack rate-limiting information to Hubot. This allows custom scripts to react to rate-limiting, for example to slow themselves down or to report to an alerting channel that a rate-limiting event has occurred.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/hubot-slack/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).