### PR TITLE
Use Coffeescript conditional assignment shorthand

### DIFF
--- a/src/bot.coffee
+++ b/src/bot.coffee
@@ -238,7 +238,7 @@ class SlackBot extends Adapter
 
       # Hubot expects all user objects to have a room property that is used in the envelope for the message after it
       # is received
-      user.room = if channel? then channel else ""
+      user.room = channel ? ""
 
       switch event.subtype
         when "bot_message"


### PR DESCRIPTION
This is a really minor syntax-only change and shouldn't affect behaviour at all.

Because what we're assigning in the happy side of this condition is the same as what we're checking in its expression we can use Coffeescript's shorthand with the existential operator, i.e. instead of

    a = if b? then b else c

use this:

    a = b ? c

Source: https://coffeescript.org/#existential-operator

###  Summary

Describe the goal of this PR. Mention any related Issue numbers.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/hubot-slack/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).