### PR TITLE
Fix #586 hubot-slack calling bots.info a suspicious number of times

### DIFF
--- a/src/client.coffee
+++ b/src/client.coffee
@@ -245,6 +245,7 @@ class SlackClient
     return Promise.resolve(@botUserIdMap[botId]) if @botUserIdMap[botId]?
 
     # Bot user is not in mapping - call bots.info
+    @robot.logger.debug "SlackClient#fetchBotUser() Calling bots.info API for bot_id: #{botId}"
     @web.bots.info(bot: botId).then((r) => r.bot)
 
   ###*
@@ -331,9 +332,13 @@ class SlackClient
     if @eventHandler
       # fetch full representations of the user, bot, and potentially the item_user.
       fetches = {}
-      fetches.user = @fetchUser event.user if event.user
-      fetches.bot = @fetchBotUser event.bot_id if event.bot_id
-      fetches.item_user = @fetchUser event.item_user if event.item_user
+      if event.bot_id
+        fetches.bot = @fetchBotUser event.bot_id
+      else if event.user
+        fetches.user = @fetchUser event.user
+
+      if event.item_user
+        fetches.item_user = @fetchUser event.item_user
 
       # after fetches complete...
       Promise.props(fetches)


### PR DESCRIPTION
###  Summary

This pull request fixes #586 by changing the internals of `SlackClient` a bit.

The latest RTM event payloads from Slack has both `user` and `bot_id` even for events generated by a bot user as below:

```json
{
  "bot_id": "B12345678",
  "suppress_notification": false,
  "type": "message",
  "text": "Badgers? BADGERS? WE DON'T NEED NO STINKIN BADGERS",
  "user": "U12345678",
  "team": "T12345678",
  "bot_profile": {
    "id": "B12345678",
    "deleted": false,
    "name": "hubot",
    "updated": 1568973776,
    "app_id": "A12345678",
    "icons": {
      "image_36": "https://a.slack-edge.com/80588/img/services/hubot_36.png",
      "image_48": "https://a.slack-edge.com/80588/img/services/hubot_48.png",
      "image_72": "https://a.slack-edge.com/80588/img/services/hubot_72.png"
    },
    "team_id": "T12345678"
  },
  "source_team": "T12345678",
  "user_team": "T12345678",
  "channel": "C12345678",
  "event_ts": "1585723843.003300",
  "ts": "1585723843.003300"
}
```

In such cases, `SlackClient`'s `@botUserIdMap` (the internal memory cache of bot user information) is not updated. That's the reason why the cache doesn't work as expected and a large number of `bots.info` calls may occur when receiving bot user events.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/hubot-slack/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).