### PR TITLE
Fix unexpected newline after super

### DIFF
--- a/src/bot.coffee
+++ b/src/bot.coffee
@@ -17,7 +17,7 @@ class SlackBot extends Adapter
   # @param {Object} options.rtmStart - options for `rtm.start` Web API method
   ###
   constructor: (@robot, @options) ->
-    super
+    super()
     @robot.logger.info "hubot-slack adapter v#{pkg.version}"
     @client = new SlackClient @options, @robot
 


### PR DESCRIPTION
###  Summary

So I know that the project has specifically pinned coffeescript 1.x in its package.json but I'm trying to use coffeescript 2.x in my project because it has other things I need (namely async/await) and the bot crashes on start, referencing this line from bot.coffee:

    [stdin]:20:10: error: unexpected newline
        super
             ^.

I supposed that this keyword has now become ambiguous without brackets/parentheses but to make sure, I dug up the breaking changes list for the coffeescript 2.0.0 release and found this:

> Due to a syntax clash with `super` with accessors, "bare" `super` (the keyword `super` without parentheses) no longer compiles to a super call forwarding all arguments.
> [...] if you know that the parent function doesn't require arguments, just call `super()`.

Source: https://coffeescript.org/#breaking-changes-super-extends

After adding the brackets the coffeelint tool no longer spits out that error and when running it it "works on my machine".  Tests are still passing and also I can't it imagine it having any adverse effects on users of older versions of coffeescript because the parentheses were optional so far.

### Requirements

* [X] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/hubot-slack/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).