### PR TITLE
Add timestamps for enter and leave messages

### DIFF
--- a/src/bot.coffee
+++ b/src/bot.coffee
@@ -272,13 +272,17 @@ class SlackBot extends Adapter
       # this event type always has a channel
       user.room = channel
       @robot.logger.debug "Received enter message for user: #{user.id}, joining: #{channel}"
-      @receive new EnterMessage user
+      msg = new EnterMessage user
+      msg.ts = event.ts
+      @receive msg
 
     else if event.type is "member_left_channel"
       # this event type always has a channel
       user.room = channel
       @robot.logger.debug "Received leave message for user: #{user.id}, joining: #{channel}"
-      @receive new LeaveMessage user
+      msg = new LeaveMessage user
+      msg.ts = event.ts
+      @receive msg
 
     else if event.type is "reaction_added" or event.type is "reaction_removed"
 

--- a/test/bot.coffee
+++ b/test/bot.coffee
@@ -223,13 +223,23 @@ describe 'Handling incoming messages', ->
     return
 
   it 'Should handle member_joined_channel events as envisioned', ->
-    @slackbot.eventHandler {type: 'member_joined_channel', user: @stubs.user, channel: @stubs.channel.id}
+    @slackbot.eventHandler
+      type: 'member_joined_channel'
+      user: @stubs.user
+      channel: @stubs.channel.id
+      ts: @stubs.event_timestamp
     should.equal @stubs._received.constructor.name, "EnterMessage"
+    should.equal @stubs._received.ts, @stubs.event_timestamp
     @stubs._received.user.id.should.equal @stubs.user.id
 
   it 'Should handle member_left_channel events as envisioned', ->
-    @slackbot.eventHandler {type: 'member_left_channel', user: @stubs.user, channel: @stubs.channel.id}
+    @slackbot.eventHandler
+      type: 'member_left_channel'
+      user: @stubs.user
+      channel: @stubs.channel.id
+      ts: @stubs.event_timestamp
     should.equal @stubs._received.constructor.name, "LeaveMessage"
+    should.equal @stubs._received.ts, @stubs.event_timestamp
     @stubs._received.user.id.should.equal @stubs.user.id
 
   it 'Should handle channel_topic events as envisioned', ->

--- a/test/stubs.coffee
+++ b/test/stubs.coffee
@@ -112,6 +112,7 @@ beforeEach ->
     name: 'Example Team'
     id: 'T123'
   @stubs.expired_timestamp = 1528238205453
+  @stubs.event_timestamp = '1360782804.083113'
 
   # Slack client
   @stubs.client =


### PR DESCRIPTION
###  Summary

Enter and leave messages don't have timestamps, unlike other events like text messages.  Hubot doesn't have a place for them e.g. for enter messages in the EnterMessage class, but Slack supports them and other actions regarding enter/leave events in Slack expect you to use a timestamp, so you need to be able to get it from somewhere.

This change works around the fact that they're not present in Hubot's classes by inserting a `ts` field after the message object has been created.  It includes tests to confirm that Slack's event timestamp is successfully passed on to Hubot.

Resolves #575

### Requirements

* [X] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/hubot-slack/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).