### PR TITLE
Add support for thread_broadcast message

### DIFF
--- a/src/bot.coffee
+++ b/src/bot.coffee
@@ -270,7 +270,7 @@ class SlackBot extends Adapter
           @robot.logger.debug "Received topic change message in conversation: #{channel}, new topic: #{event.topic}, set by: #{user.id}"
           @receive new TopicMessage user, event.topic, event.ts
 
-        when undefined
+        when "thread_broadcast", undefined
           @robot.logger.debug "Received text message in channel: #{channel}, from: #{user.id} (human)"
           SlackTextMessage.makeSlackTextMessage(user, undefined, undefined, event, channel, @robot.name, @robot.alias, @client, (error, message) =>
             return @robot.logger.error "Dropping message due to error #{error.message}" if error

--- a/test/bot.coffee
+++ b/test/bot.coffee
@@ -188,6 +188,13 @@ describe 'Handling incoming messages', ->
     @slackbot.eventHandler {type: 'message', text: 'foo', user: @stubs.user, channel: @stubs.channel.id }
     return
 
+  it 'Should handle broadcasted messages', (done) ->
+    @stubs.receiveMock.onReceived = (msg) ->
+      msg.text.should.equal 'foo'
+      done()
+    @slackbot.eventHandler {type: 'message', text: 'foo', subtype: 'thread_broadcast', user: @stubs.user, channel: @stubs.channel.id }
+    return
+
   it 'Should prepend our name to a name-lacking message addressed to us in a DM', ->
     bot_name = @slackbot.robot.name
     @stubs.receiveMock.onReceived = (msg) ->


### PR DESCRIPTION
###  Summary

Hubot cannot hear a reply message broadcasted to channel (sent with `Also send to #channel` checked).

### How to reproduce

Write following script:

```
module.exports = robot => {
  robot.hear(/^test$/i, msg => console.log(msg.match));
}
```

1. When we send message `test` to a channel or thread, we can see `console.log` output as expected.
2. When we send message `test` to a thread with checking `Also send to #channel`, we also expect same log to be seen, but we cannot see the log.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/hubot-slack/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).