### PR TITLE
threaded replies

### DIFF
--- a/src/client.coffee
+++ b/src/client.coffee
@@ -188,7 +188,8 @@ class SlackClient
       # when the incoming message was inside a thread, send responses as replies to the thread
       # NOTE: consider building a new (backwards-compatible) format for room which includes the thread_ts.
       # e.g. "#{conversationId} #{thread_ts}" - this would allow a portable way to say the message is in a thread
-      thread_ts: envelope.message?.thread_ts
+      thread_ts: envelope.message?.thread_ts,
+      reply_broadcast: envelope.message?.reply_broadcast
 
     if typeof message isnt "string"
       @web.chat.postMessage(room, message.text, _.defaults(message, options))

--- a/src/message.coffee
+++ b/src/message.coffee
@@ -103,6 +103,22 @@ class SlackTextMessage extends TextMessage
     # base text
     text = if @rawMessage.text? then @rawMessage.text else ""
 
+    # Catch and consume thread arguments
+    pos = text.indexOf(" --thread_broadcast")
+    if pos > -1
+      text = text.substring(0, pos) + text.substring(pos + 19)
+      @requestedThreadStyle = 2
+
+    pos = text.indexOf(" --nothread")
+    if pos > -1
+      text = text.substring(0, pos) + text.substring(pos + 11)
+      @requestedThreadStyle = 0
+
+    pos = text.indexOf(" --thread")
+    if pos > -1
+      text = text.substring(0, pos) + text.substring(pos + 9)
+      @requestedThreadStyle = 1
+
     # flatten any attachments into text
     if @rawMessage.attachments
       attachment_text = @rawMessage.attachments.map((a) -> a.fallback).join("\n")

--- a/test/message.coffee
+++ b/test/message.coffee
@@ -156,6 +156,33 @@ describe 'buildText()', ->
     message.buildText @client, () ->
       message.text.should.equal 'foo bar\nfirst\nsecond'
 
+  it 'Should ignore requestedThreadStyle if not set', ->
+    message = @slacktextmessage
+    message.rawMessage.text = 'foo bar'
+    message.buildText @client, () ->
+      message.text.should.equal('foo bar')
+      should.equal message.requestedThreadStyle, undefined
+
+  it 'Should consume `--thread` argument', ->
+    message = @slacktextmessage
+    message.rawMessage.text = 'foo --thread'
+    message.buildText @client, () ->
+      message.text.should.equal('foo')
+      message.requestedThreadStyle.should.equal 1
+
+  it 'Should consume `--thread_broadcast` argument', ->
+    message = @slacktextmessage
+    message.rawMessage.text = 'foo --thread_broadcast'
+    message.buildText @client, () ->
+      message.text.should.equal('foo')
+      message.requestedThreadStyle.should.equal 2
+
+  it 'Should consume `--nothread` argument', ->
+    message = @slacktextmessage
+    message.rawMessage.text = 'foo --nothread'
+    message.buildText @client, () ->
+      message.text.should.equal('foo')
+      message.requestedThreadStyle.should.equal 0
 
 describe 'replaceLinks()', ->
 


### PR DESCRIPTION
###  Summary

This effort started as part of a hackathon project, so I don't actually have an enhancement request issue tracking this. I'd like hubot to be able to reply in Slack threads, and I believe the changes here are low risk. This PR would work in conjunction with https://github.com/hubotio/hubot/pull/1557 and allow you to specify `--thread`, etc., to make any chatop threaded. Chatops can be defined to thread by default and you would be able to override that with `--nothread`, etc.

(Note: this PR exists in alternative form https://github.com/github/hubot-slack/pull/22 but I was guided to submit here first.)

![image](https://user-images.githubusercontent.com/14298027/127349203-2fca08d5-e59b-4750-ae50-8d595a5e0026.png)


### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/hubot-slack/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).