### PR TITLE
Fix #643 Resolve undefined user ID in debug logging

### DIFF
--- a/src/bot.coffee
+++ b/src/bot.coffee
@@ -332,7 +332,7 @@ class SlackBot extends Adapter
       # conversation. In that situation we fallback to an empty string.
       user.room = event.channel_id
 
-      @robot.logger.debug "Received file_shared message from: #{user.id}, file_id: #{event.file_id}"
+      @robot.logger.debug "Received file_shared message from: #{event.user_id}, file_id: #{event.file_id}"
       @receive new FileSharedMessage(user, event.file_id, event.event_ts)
 
 


### PR DESCRIPTION
###  Summary

This pull request resolves #643 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/hubot-slack/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).